### PR TITLE
feat: add l402_log_format directive for structured JSON access logs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -286,6 +286,86 @@ jobs:
 
           echo "✅ Dry-run shadow mode & metrics integration tests completed!"
 
+      - name: Run Integration Tests - Structured JSON Logging
+        run: |
+          echo "Testing l402_log_format json structured access logs..."
+
+          # Unauthenticated request → 402 path → l402_challenge. If the LN
+          # backend flakes we get l402_challenge_error instead; either event
+          # proves the JSON pipeline (same tolerance as the dry-run section).
+          echo "Request to /json-logs without Authorization (expect 402)..."
+          response=$(curl -s -w "\n%{http_code}" --max-time 30 -H "Connection: close" http://0.0.0.0:8000/json-logs) || true
+          status_code=$(echo "$response" | tail -n1); status_code=${status_code:-000}
+          if [ "$status_code" -ne 402 ] && [ "$status_code" -ne 500 ]; then
+            echo "FAIL: /json-logs returned $status_code, expected 402 (or 500 on LN backend failure)"
+            docker logs nginx-lnurl
+            exit 1
+          fi
+          echo "PASS: /json-logs returned $status_code"
+
+          # Invalid credentials → 401 path → l402_verify with auth_state=invalid.
+          # The macaroon is path-bound to /protected, so on /json-logs it is
+          # simply an invalid credential, which is all this test needs.
+          echo "Request to /json-logs with invalid preimage (expect 401)..."
+          response=$(curl -s -w "\n%{http_code}" --max-time 30 -H "Authorization: L402 MDAxMmxvY2F0aW9uIEw0MDIKMDAzMGlkZW50aWZpZXIgM460twjJAuVrQN-u5JPUZ0aKNWevybkbveRc2DeF2ZAKMDAyMWNpZCBSZXF1ZXN0UGF0aCA9IC9wcm90ZWN0ZWQKMDAyZnNpZ25hdHVyZSCwR6G2lDj1thda81BPwQuo73_shURzPf1XOwuejNLwVwo=:fbe9ac25c04e14b10177514e2d57b0e39224e70277ac1a2cd23c28e58cd4ea35" -H "Connection: close" http://0.0.0.0:8000/json-logs) || true
+          status_code=$(echo "$response" | tail -n1); status_code=${status_code:-000}
+          if [ "$status_code" -ne 401 ]; then
+            echo "FAIL: /json-logs with invalid preimage returned $status_code, expected 401"
+            docker logs nginx-lnurl
+            exit 1
+          fi
+          echo "PASS: /json-logs returned 401 for invalid preimage"
+
+          # /json-logs allows 1 invoice/minute and the first request already
+          # used it, so this one must be rate-limited → l402_rate_limited.
+          # The 401 in between does not consume the limit (only 402s do).
+          echo "Second unauthenticated request to /json-logs (expect 429)..."
+          response=$(curl -s -w "\n%{http_code}" --max-time 30 -H "Connection: close" http://0.0.0.0:8000/json-logs) || true
+          status_code=$(echo "$response" | tail -n1); status_code=${status_code:-000}
+          if [ "$status_code" -ne 429 ]; then
+            echo "FAIL: second /json-logs request returned $status_code, expected 429 (1r/m limit)"
+            docker logs nginx-lnurl
+            exit 1
+          fi
+          echo "PASS: /json-logs returned 429 over the rate limit"
+
+          # Let nginx flush the error log before asserting on it.
+          sleep 2
+          logs=$(docker logs nginx-lnurl 2>&1)
+
+          if ! echo "$logs" | grep -q '"event":"l402_challenge".*"route":"/json-logs"' && \
+             ! echo "$logs" | grep -q '"event":"l402_challenge_error".*"route":"/json-logs"'; then
+            echo "FAIL: no l402_challenge/l402_challenge_error JSON event for /json-logs"
+            echo "$logs" | tail -50
+            exit 1
+          fi
+          echo "PASS: l402_challenge JSON event present for /json-logs"
+
+          if ! echo "$logs" | grep -q '"event":"l402_verify".*"route":"/json-logs".*"auth_state":"invalid"'; then
+            echo "FAIL: no l402_verify auth_state=invalid JSON event for /json-logs"
+            echo "$logs" | tail -50
+            exit 1
+          fi
+          echo "PASS: l402_verify auth_state=invalid JSON event present"
+
+          if ! echo "$logs" | grep -q '"event":"l402_rate_limited".*"route":"/json-logs"'; then
+            echo "FAIL: no l402_rate_limited JSON event for /json-logs"
+            echo "$logs" | tail -50
+            exit 1
+          fi
+          echo "PASS: l402_rate_limited JSON event present for /json-logs"
+
+          # /protected never enabled the directive: earlier sections drove plenty
+          # of traffic through it, and none of it may appear as a JSON event.
+          if echo "$logs" | grep -q '"event":"l402_.*"route":"/protected"'; then
+            echo "FAIL: found l402 JSON event for /protected, which runs default text logging"
+            echo "$logs" | grep '"event":"l402_' | tail -10
+            exit 1
+          fi
+          echo "PASS: no JSON events for /protected (text default unchanged)"
+
+          echo "✅ Structured JSON logging integration tests completed!"
+
       - name: Run Integration Tests - gRPC
         run: |
           source .github/scripts/ci-wait.sh

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -329,7 +329,7 @@ jobs:
           fi
           echo "PASS: /json-logs returned 429 over the rate limit"
 
-          # Let nginx flush the error log before asserting on it.
+          # Let nginx flush the container logs before asserting on them.
           sleep 2
           logs=$(docker logs nginx-lnurl 2>&1)
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -267,6 +267,9 @@ services:
       - CASHU_REDEMPTION_INTERVAL_SECS=15
       - CASHU_WHITELISTED_MINTS=${CASHU_WHITELISTED_MINTS}
       - REDIS_URL=redis://redis:6379
+      # info! lines (including the l402_log_format json events) only reach the
+      # container log if env_logger's filter allows them; default is error-only.
+      - RUST_LOG=info
     volumes:
       - cashu-data:/app/data
     depends_on:

--- a/docs/config-env-vars.md
+++ b/docs/config-env-vars.md
@@ -281,6 +281,7 @@ These are set inside `location {}` blocks in `nginx.conf` (not environment varia
 | `l402_auto_detect_payment` | boolean¹ | `off` | Server-side payment detection — queries the Lightning node instead of requiring the client to supply the preimage |
 | `l402_indefinite_access` | boolean¹ | `off` | Skip the single-use preimage replay check — a single payment stays valid for the macaroon lifetime |
 | `l402_realm` | string | — | Bind the macaroon to a named protection space instead of the exact request path, so one payment authorizes every location sharing the name |
+| `l402_log_format` | `json` or `text` | `text` | Emit one structured JSON line per L402 access event (verify, challenge, challenge error, rate-limited) — see [logging.md](logging.md) |
 
 > ¹ **Boolean directives** accept: `on` / `off` / `true` / `false` / `1` / `0` / `yes` / `no` (case-insensitive).
 

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -37,3 +37,17 @@ Environment=RUST_LOG=debug
 # Module-specific debug logs only (reduces noise)
 Environment=RUST_LOG=ngx_l402_lib=debug,info
 ```
+
+---
+
+## Structured JSON Logs
+
+Set `l402_log_format json;` on a protected location to emit one JSON line per L402 access event, alongside the usual text logs. Field names match the dry-run line, so the same `jq` / log-aggregator queries work for both:
+
+```json
+{"event":"l402_verify","route":"/api/data","backend":"lnd","client_ip":"203.0.113.7","auth_state":"valid","method":"lightning","latency_ms":42}
+```
+
+Events: `l402_verify` (`auth_state` valid or invalid, `method` when known), `l402_challenge` (a 402 was issued, with `price_msat` and `price_source`), `l402_challenge_error` (`error`: `backend`, `timeout`, or `panic`), and `l402_rate_limited` (a 429, with `window_secs`).
+
+Off by default (`text`), so existing deployments see no change. The directive is per-location: an inner `l402_log_format text;` overrides an outer `json`.

--- a/nginx.conf
+++ b/nginx.conf
@@ -84,6 +84,22 @@ http {
             try_files $uri $uri/index.html =404;
         }
 
+        # Structured JSON logging endpoint: same as /protected but with
+        # l402_log_format json, so CI can assert the l402_* JSON events land
+        # in the container logs. A 1r/m invoice rate limit lets the same CI
+        # section cover the l402_rate_limited event. /protected stays on text
+        # logging so the same CI run also proves the default is unchanged.
+        location /json-logs {
+            root   /usr/share/nginx/html;
+            l402    on;
+            l402_amount_msat_default    10000;
+            l402_macaroon_timeout 0;
+            l402_log_format json;
+            l402_invoice_rate_limit 1r/m;
+
+            try_files $uri $uri/index.html =404;
+        }
+
         location /protected-timeout {
             root   /usr/share/nginx/html;
             # l402 module directives:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1345,6 +1345,11 @@ pub struct ModuleConfig {
     // (inherit from parent scope); `Some(false)` explicitly turns it off and
     // stops inheritance.
     dry_run: Option<bool>,
+    // Structured JSON access logging (`l402_log_format json`). Tri-state like
+    // dry_run so an inner location can force it off when an outer scope turned
+    // it on. Unset everywhere means the default text logging — existing
+    // deployments see no change.
+    log_format_json: Option<bool>,
     // Skip single-use preimage replay check; one payment stays valid for the
     // macaroon lifetime (pair with l402_macaroon_timeout). `None` means unset
     // (inherit from parent scope); `Some(false)` explicitly turns it off and
@@ -1356,7 +1361,7 @@ pub struct ModuleConfig {
     manifest_hidden: bool,
 }
 
-pub static mut NGX_HTTP_L402_COMMANDS: [ngx_command_t; 13] = [
+pub static mut NGX_HTTP_L402_COMMANDS: [ngx_command_t; 14] = [
     ngx_command_t {
         name: ngx_string!("l402"),
         type_: (NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1) as ngx_uint_t,
@@ -1454,6 +1459,14 @@ pub static mut NGX_HTTP_L402_COMMANDS: [ngx_command_t; 13] = [
         offset: 0,
         post: std::ptr::null_mut(),
     },
+    ngx_command_t {
+        name: ngx_string!("l402_log_format"),
+        type_: (NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1) as ngx_uint_t,
+        set: Some(ngx_http_l402_log_format_set),
+        conf: NGX_HTTP_LOC_CONF_OFFSET,
+        offset: 0,
+        post: std::ptr::null_mut(),
+    },
     ngx_command_t::empty(),
 ];
 
@@ -1534,6 +1547,9 @@ impl Merge for ModuleConfig {
         // location overrides `l402_dry_run on;` on the outer scope.
         if self.dry_run.is_none() {
             self.dry_run = prev.dry_run;
+        }
+        if self.log_format_json.is_none() {
+            self.log_format_json = prev.log_format_json;
         }
         if prev.manifest_hidden {
             self.manifest_hidden = true;
@@ -1741,6 +1757,7 @@ pub unsafe extern "C" fn l402_access_handler_wrapper(request: *mut ngx_http_requ
         dry_run,
         indefinite_access,
         realm,
+        log_format_json,
     ) = unsafe {
         // NOTE: `authorization` can be null — not every request carries the header.
         let auth_header = if !r.headers_in.authorization.is_null() {
@@ -1797,6 +1814,7 @@ pub unsafe extern "C" fn l402_access_handler_wrapper(request: *mut ngx_http_requ
         let dry_run = conf.dry_run.unwrap_or(false);
         let indefinite_access = conf.indefinite_access.unwrap_or(false);
         let realm = conf.realm.clone();
+        let log_format_json = conf.log_format_json.unwrap_or(false);
 
         (
             auth_header,
@@ -1810,6 +1828,7 @@ pub unsafe extern "C" fn l402_access_handler_wrapper(request: *mut ngx_http_requ
             dry_run,
             indefinite_access,
             realm,
+            log_format_json,
         )
     };
 
@@ -1914,18 +1933,51 @@ pub unsafe extern "C" fn l402_access_handler_wrapper(request: *mut ngx_http_requ
     match result {
         r if r == NGX_DECLINED as isize => {
             metrics::inc(metrics::Metric::PaymentsValidTotal);
-            match LAST_PAYMENT_METHOD.with(|m| m.take()) {
+            let payment_method = LAST_PAYMENT_METHOD.with(|m| m.take());
+            match payment_method {
                 Some(PaymentMethod::Lightning) => {
                     metrics::inc(metrics::Metric::PaymentsLightningTotal)
                 }
                 Some(PaymentMethod::Cashu) => metrics::inc(metrics::Metric::PaymentsCashuTotal),
                 None => {}
             }
+            if log_format_json {
+                let method_field = match payment_method {
+                    Some(PaymentMethod::Lightning) => ",\"method\":\"lightning\"",
+                    Some(PaymentMethod::Cashu) => ",\"method\":\"cashu\"",
+                    None => "",
+                };
+                log_json_event(
+                    "l402_verify",
+                    &request_path,
+                    backend_label(),
+                    &format!(
+                        ",\"client_ip\":\"{}\",\"auth_state\":\"valid\"{},\"latency_ms\":{}",
+                        ngx_l402_core::escape_json(&get_client_ip(request)),
+                        method_field,
+                        auth_duration.as_millis()
+                    ),
+                );
+            }
         }
         // 400 joins 401: a Cashu token rejected under NUT-24 is an invalid
         // payment, same as a bad preimage. 500 stays out — that is our failure,
         // not the payer's, and must not inflate the invalid-payment count.
-        400 | 401 => metrics::inc(metrics::Metric::PaymentsInvalidTotal),
+        400 | 401 => {
+            metrics::inc(metrics::Metric::PaymentsInvalidTotal);
+            if log_format_json {
+                log_json_event(
+                    "l402_verify",
+                    &request_path,
+                    backend_label(),
+                    &format!(
+                        ",\"client_ip\":\"{}\",\"auth_state\":\"invalid\",\"latency_ms\":{}",
+                        ngx_l402_core::escape_json(&get_client_ip(request)),
+                        auth_duration.as_millis()
+                    ),
+                );
+            }
+        }
         402 => metrics::inc(metrics::Metric::PaymentsMissingTotal),
         _ => {}
     }
@@ -1958,6 +2010,18 @@ pub unsafe extern "C" fn l402_access_handler_wrapper(request: *mut ngx_http_requ
                     client_ip,
                     request_path
                 );
+                if log_format_json {
+                    log_json_event(
+                        "l402_rate_limited",
+                        &request_path,
+                        backend_label(),
+                        &format!(
+                            ",\"client_ip\":\"{}\",\"window_secs\":{}",
+                            ngx_l402_core::escape_json(&client_ip),
+                            window_secs
+                        ),
+                    );
+                }
                 // SAFETY: `request` is non-null and valid for this handler's
                 // lifetime, as guaranteed by nginx before invoking the handler.
                 unsafe {
@@ -2039,6 +2103,9 @@ pub unsafe extern "C" fn l402_access_handler_wrapper(request: *mut ngx_http_requ
         // worker's first request builds its own channel: this catches a request
         // that will never finish, it is not a latency budget.
         const CHALLENGE_TIMEOUT: Duration = Duration::from_secs(25);
+        // Remember *why* challenge synthesis failed so the JSON event can
+        // carry an error type instead of a free-form message.
+        let mut challenge_error_kind: Option<&'static str> = None;
         let header_result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
             rt.block_on(async {
                 tokio::time::timeout(
@@ -2054,10 +2121,12 @@ pub unsafe extern "C" fn l402_access_handler_wrapper(request: *mut ngx_http_requ
             })
         }))
         .unwrap_or_else(|_| {
+            challenge_error_kind = Some("panic");
             error!("❌ Panic in get_l402_header (LNURL resolution failure); returning 500");
             Ok(None)
         })
         .unwrap_or_else(|_| {
+            challenge_error_kind = Some("timeout");
             error!(
                 "❌ Invoice generation timed out after {}s",
                 CHALLENGE_TIMEOUT.as_secs()
@@ -2076,6 +2145,20 @@ pub unsafe extern "C" fn l402_access_handler_wrapper(request: *mut ngx_http_requ
         match header_result {
             Some(header_value) => {
                 metrics::inc(metrics::Metric::InvoicesGeneratedTotal);
+                if log_format_json {
+                    log_json_event(
+                        "l402_challenge",
+                        &request_path,
+                        backend_label(),
+                        &format!(
+                            ",\"client_ip\":\"{}\",\"auth_state\":\"missing\",\"price_msat\":{},\"price_source\":\"{}\",\"latency_ms\":{}",
+                            ngx_l402_core::escape_json(&get_client_ip(request)),
+                            final_amount,
+                            price_source,
+                            invoice_start.elapsed().as_millis()
+                        ),
+                    );
+                }
 
                 // Set WWW-Authenticate header for API clients
                 unsafe {
@@ -2119,6 +2202,19 @@ pub unsafe extern "C" fn l402_access_handler_wrapper(request: *mut ngx_http_requ
             None => {
                 metrics::inc(metrics::Metric::InvoicesGenerationErrorsTotal);
                 ngx_log_error!(NGX_LOG_ERR, log_ref, "Failed to get L402 header");
+                if log_format_json {
+                    log_json_event(
+                        "l402_challenge_error",
+                        &request_path,
+                        backend_label(),
+                        &format!(
+                            ",\"client_ip\":\"{}\",\"error\":\"{}\",\"latency_ms\":{}",
+                            ngx_l402_core::escape_json(&get_client_ip(request)),
+                            challenge_error_kind.unwrap_or("backend"),
+                            invoice_start.elapsed().as_millis()
+                        ),
+                    );
+                }
                 return 500;
             }
         }
@@ -2754,6 +2850,32 @@ fn spawn_cashu_redemption_thread(interval_secs: u64) {
     }
 }
 
+/// Label for the active Lightning backend, cached at init. Shared by the
+/// dry-run line and the `l402_log_format json` events so log pipelines can
+/// group every structured line by the same value.
+fn backend_label() -> &'static str {
+    LN_BACKEND_LABEL
+        .get()
+        .map(String::as_str)
+        .unwrap_or("unknown")
+}
+
+/// Emit one structured JSON access event. Only called when the location has
+/// `l402_log_format json`; field names follow the dry-run line (`event` as
+/// discriminator, `route`, `backend`, `auth_state`) so the same log-pipeline
+/// queries match both. `extra_fields` is a pre-built fragment of
+/// `,"key":value` pairs — every interpolated string value must go through
+/// `escape_json` at the call site.
+fn log_json_event(event: &str, route: &str, backend: &str, extra_fields: &str) {
+    info!(
+        "{{\"event\":\"{event}\",\"route\":\"{route}\",\"backend\":\"{backend}\"{extra}}}",
+        event = event,
+        route = ngx_l402_core::escape_json(route),
+        backend = backend,
+        extra = extra_fields,
+    );
+}
+
 /// Handle dry-run (shadow) mode: evaluate everything, log + increment metrics,
 /// but never block the request. Always returns [`NGX_DECLINED`] so nginx
 /// continues to the next phase and the upstream response is served as 200.
@@ -3014,6 +3136,47 @@ pub unsafe extern "C" fn ngx_http_l402_dry_run_set(
         } else {
             error!("Invalid l402_dry_run value: '{}' (expected on/off)", val);
             return c"l402_dry_run: expected 'on' or 'off'".as_ptr() as *mut c_char;
+        }
+    }
+    std::ptr::null_mut()
+}
+
+/// Directive handler for `l402_log_format json|text;`.
+///
+/// `json` emits one structured line per L402 access event (verify, challenge,
+/// challenge error, rate-limited) with the same field names as the dry-run
+/// line. `text` (the default) keeps the free-form logs. Opt-in per location;
+/// an inner location can force `text` when an outer scope set `json`.
+///
+/// # Safety
+/// `cf` and `conf` are the valid, non-null pointers Nginx passes to
+/// directive-parsing callbacks; `conf` points to this location's
+/// `ModuleConfig`. `(*cf).args` holds exactly one argument because the
+/// directive is declared `NGX_CONF_TAKE1`.
+pub unsafe extern "C" fn ngx_http_l402_log_format_set(
+    cf: *mut ngx_conf_t,
+    _cmd: *mut ngx_command_t,
+    conf: *mut c_void,
+) -> *mut c_char {
+    // SAFETY: `cf`, `conf`, and `(*cf).args` are guaranteed valid by Nginx
+    // during config-parsing callbacks. `args.add(1)` is safe because
+    // NGX_CONF_TAKE1 ensures exactly one argument is present.
+    unsafe {
+        let conf = &mut *(conf as *mut ModuleConfig);
+        let args = (*(*cf).args).elts as *mut ngx_str_t;
+        let val = (*args.add(1)).to_str().unwrap_or_default();
+
+        if val.eq_ignore_ascii_case("json") {
+            conf.log_format_json = Some(true);
+            info!("⚙️ l402_log_format json enabled (structured access logs)");
+        } else if val.eq_ignore_ascii_case("text") {
+            conf.log_format_json = Some(false);
+        } else {
+            error!(
+                "Invalid l402_log_format value: '{}' (expected json/text)",
+                val
+            );
+            return c"l402_log_format: expected 'json' or 'text'".as_ptr() as *mut c_char;
         }
     }
     std::ptr::null_mut()


### PR DESCRIPTION
## What

Adds an opt-in `l402_log_format json` directive that emits one structured JSON line per L402 access event: `l402_verify` (valid/invalid), `l402_challenge`, `l402_challenge_error`, `l402_rate_limited`. Text logs still emit, and the default is `text`, so existing deployments see no change.

## Why

Right now almost every L402 event is logged as free-form text. Filtering verification outcomes or errors by backend, route, or outcome in a log aggregator means writing regexes against message strings, and those break the moment someone rewords a log line. This extends the dry-run line's JSON pattern to the whole handler, so every verification, challenge, and rate-limit decision becomes queryable by field instead of by regex.

## How

- `ModuleConfig` gains a tri-state `log_format_json: Option<bool>`, merged like `l402_dry_run`: an inner location can force `text` when an outer scope sets `json`.
- One `log_json_event` helper emits from the handler's exit points. Attacker-controlled strings (route, client IP) go through the existing `escape_json` at every call site. The backend label is snapshotted pre-fork, so workers never read env vars. Challenge failures carry a structured `error` field (`panic`/`timeout`/`backend`) instead of a rewordable message.

## Testing

- [x] `cargo fmt --check` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] New "Structured JSON Logging" section in `tests.yml`

Closes #146

[Nostr proposal](https://gitworkshop.dev/npub1qnw27f2jsqvn05wzpd56m7ykgmepk57p0yrzw8fzc7lfhjkmjmqqmd9r6h/ngx-l402/prs/nevent1qqsx7degz2yuspc5nru7yqqpt7q6sl2mzuqq8zw4cep8a600aaqg6ngpz3mhxue69uhhyetvv9ujumn8d96zuer9wc2c5s6k)
