### PR TITLE
fix: skip runtime initialization during nginx -t

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,13 +9,13 @@ use ngx::ffi::{
     ngx_http_discard_request_body, ngx_http_finalize_request, ngx_http_handler_pt,
     ngx_http_module_t, ngx_http_phases_NGX_HTTP_ACCESS_PHASE, ngx_http_request_t, ngx_int_t,
     ngx_log_s, ngx_module_t, ngx_shared_memory_add, ngx_shm_zone_t, ngx_slab_alloc,
-    ngx_slab_pool_t, ngx_str_t, ngx_uint_t, NGX_CONF_NOARGS, NGX_CONF_TAKE1, NGX_DECLINED,
-    NGX_DONE, NGX_ERROR, NGX_HTTP_COPY, NGX_HTTP_DELETE, NGX_HTTP_GET, NGX_HTTP_HEAD,
+    ngx_slab_pool_t, ngx_str_t, ngx_test_config, ngx_uint_t, NGX_CONF_NOARGS, NGX_CONF_TAKE1,
+    NGX_DECLINED, NGX_DONE, NGX_ERROR, NGX_HTTP_COPY, NGX_HTTP_DELETE, NGX_HTTP_GET, NGX_HTTP_HEAD,
     NGX_HTTP_INTERNAL_SERVER_ERROR, NGX_HTTP_LOCK, NGX_HTTP_LOC_CONF, NGX_HTTP_LOC_CONF_OFFSET,
     NGX_HTTP_MAIN_CONF, NGX_HTTP_MKCOL, NGX_HTTP_MODULE, NGX_HTTP_MOVE, NGX_HTTP_NOT_ALLOWED,
     NGX_HTTP_OPTIONS, NGX_HTTP_PATCH, NGX_HTTP_POST, NGX_HTTP_PROPFIND, NGX_HTTP_PROPPATCH,
     NGX_HTTP_PUT, NGX_HTTP_SRV_CONF, NGX_HTTP_TRACE, NGX_HTTP_UNLOCK, NGX_LOG_ERR, NGX_LOG_INFO,
-    NGX_LOG_WARN, NGX_OK, NGX_RS_MODULE_SIGNATURE,
+    NGX_LOG_NOTICE, NGX_LOG_WARN, NGX_OK, NGX_RS_MODULE_SIGNATURE,
 };
 use ngx::http::{
     HTTPStatus, HttpModule, HttpModuleLocationConf, HttpModuleMainConf, HttpModuleServerConf,
@@ -2388,6 +2388,23 @@ pub unsafe extern "C" fn init_module(cycle: *mut ngx_cycle_s) -> isize {
     // SAFETY: `cycle->log` is guaranteed valid by Nginx before invoking
     // module init callbacks; it points to the global error log.
     let log = (*cycle).log;
+
+    // `nginx -t` only validates the configuration files. Nothing below reads
+    // them: it builds the Tokio runtime, the Lightning backend client and the
+    // LNURL cache, all of which exist to serve requests.
+    //
+    // SAFETY: `ngx_test_config` is set by nginx while parsing `-t` in
+    // `ngx_get_options`, before `ngx_init_cycle` invokes any init_module
+    // callback. It is read-only from then on, and read here in the
+    // single-threaded master before any fork.
+    if ngx_test_config != 0 {
+        ngx_log_error!(
+            NGX_LOG_NOTICE,
+            log,
+            "ngx_l402: config test, skipping runtime initialisation"
+        );
+        return NGX_OK as isize;
+    }
 
     // Initialize logger - this is critical for RUST_LOG to work
     let _ = env_logger::try_init();


### PR DESCRIPTION
## What

Return `NGX_OK` early from `init_module` when nginx is running a config test
(`ngx_test_config != 0`), instead of building the runtime and Lightning client.

## Why

On a correctly configured host — module serving traffic, `ROOT_KEY` supplied via a
systemd drop-in — `sudo nginx -t` aborted with SIGABRT rather than reporting success:

```
nginx: the configuration file /etc/nginx/nginx.conf syntax is ok

thread '<unnamed>' (88384) panicked at src/lib.rs:59:17:
ROOT_KEY environment variable is not set. Generate one with: openssl rand -hex 32
fatal runtime error: failed to initiate panic, error 5, aborting
ngx_l402: worker died on signal 6
```

A config test run from a shell does not inherit the unit's environment, so
`require_root_key()` panics during module init and the Rust runtime aborts (a panic
cannot unwind across the FFI boundary).

This matters beyond an interactive shell: `nginx -t` is the standard pre-reload
validation used by deploy scripts, Ansible handlers, CI config checks and certbot's
renewal hook. None of them carry the unit environment either, so all of them see a
crashed process on an install that is in fact working.

## How

`init_module` checks `ngx_test_config` before doing any runtime work. The symbol is
already present in the generated `nginx-sys` bindings, so no binding changes are needed.

Nothing below the early return contributes to validating configuration — it builds the
Tokio runtime, the Lightning backend client and the LNURL cache, all of which exist to
serve requests and all of which require operator-supplied environment.

Directive-level validation is unaffected: it runs in `Merge` during config parsing,
which happens before any `init_module` callback, so `-t` still rejects e.g.
`l402_realm` without `l402_indefinite_access`. Only environment-dependent
initialisation is skipped, which a config test could not perform meaningfully anyway.

Per review, the early return logs at `[notice]` so a passing `-t` does not imply the
module was initialised when it was not:

```
[notice] 249364#249364: ngx_l402: config test, skipping runtime initialisation
```

This change is independent of, and complementary to, making `require_root_key`
fallible so a genuinely missing key at real startup produces `[emerg]` + `return -1`
instead of an abort. At real startup `ngx_test_config` is 0, so that path is unchanged
here.

## Testing

| Case | Before | After |
|---|---|---|
| `nginx -t`, no `ROOT_KEY` | SIGABRT, exit 134 | `test is successful`, exit 0 |
| `nginx -t`, with `ROOT_KEY` | successful | successful, exit 0 |
| Serving a request | 402 + challenge | 402 + challenge, unchanged |
| Real startup, no `ROOT_KEY` | SIGABRT, exit 134 | SIGABRT, exit 134 (unchanged, by design) |

- [x] Manually tested with Nginx (1.28.3, Ubuntu, `LN_CLIENT_TYPE=LNURL`)
- [x] `cargo test -p ngx_l402_core` — 52 passed
- [ ] Unit tests added/updated — not applicable; `init_module` is FFI and cannot be
      unit tested outside Nginx
- [ ] Load tested — not applicable; no request-path change

## Checklist

- [x] `cargo fmt --check` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo build --release --features export-modules`
- [x] No breaking changes
- [ ] Benchmark results — not a performance change

Closes #172
