### PR TITLE
fix: format errors with Display so a wrapped secret cannot leak

### DIFF
--- a/src/cashu.rs
+++ b/src/cashu.rs
@@ -118,7 +118,7 @@ async fn get_db() -> Result<Arc<cdk_sqlite::WalletSqliteDatabase>, String> {
             cdk_sqlite::WalletSqliteDatabase::new(url.as_str())
                 .await
                 .map(Arc::new)
-                .map_err(|e| format!("Failed to open Cashu database: {:?}", e))
+                .map_err(|e| format!("Failed to open Cashu database: {}", e))
         })
         .await
         .cloned()
@@ -536,7 +536,7 @@ fn verify_proof_dleq_offline(
             })?;
             proof
                 .verify_dleq(key)
-                .map_err(|e| format!("NUT-12 DLEQ verification failed: {:?}", e))
+                .map_err(|e| format!("NUT-12 DLEQ verification failed: {}", e))
         }
         None => {
             if require_dleq {
@@ -618,7 +618,7 @@ pub fn initialize_cashu(db_url: &str) -> Result<(), String> {
                 Ok(())
             }
             Err(e) => {
-                let error = format!("Failed to create Cashu SQLite database: {:?}", e);
+                let error = format!("Failed to create Cashu SQLite database: {}", e);
                 error!("❌ {}", error);
                 Err(error)
             }
@@ -1251,7 +1251,7 @@ pub async fn verify_cashu_token_p2pk(
     );
     // Re-parse to a typed MintUrl (needed for ProofInfo and wallet APIs)
     let mint_url = MintUrl::from_str(&mint_url_str).map_err(|e| {
-        CashuError::Unacceptable(format!("Invalid mint URL after normalization: {:?}", e))
+        CashuError::Unacceptable(format!("Invalid mint URL after normalization: {}", e))
     })?;
 
     // Verify mint is whitelisted
@@ -1342,7 +1342,7 @@ pub async fn verify_cashu_token_p2pk(
             .map(|p| {
                 p.y().map(|y| y.to_hex()).map_err(|e| {
                     CashuError::Internal(format!(
-                        "Failed to compute proof Y-value for replay key: {:?}",
+                        "Failed to compute proof Y-value for replay key: {}",
                         e
                     ))
                 })
@@ -1370,7 +1370,7 @@ pub async fn verify_cashu_token_p2pk(
     ))?;
 
     let public_key = cdk::nuts::PublicKey::from_hex(public_key_str)
-        .map_err(|e| CashuError::Internal(format!("Failed to parse public key: {:?}", e)))?;
+        .map_err(|e| CashuError::Internal(format!("Failed to parse public key: {}", e)))?;
 
     // Create spending condition with our public key
     let spending_condition = cdk::nuts::SpendingConditions::new_p2pk(public_key, None);
@@ -1381,7 +1381,7 @@ pub async fn verify_cashu_token_p2pk(
         .verify_token_p2pk(&token_decoded, spending_condition.clone())
         .await
         .map_err(|e| {
-            CashuError::Unacceptable(format!("Token not locked to our public key: {:?}", e))
+            CashuError::Unacceptable(format!("Token not locked to our public key: {}", e))
         })?;
 
     info!("✅ Token verified as P2PK-locked to our public key");
@@ -1439,7 +1439,7 @@ pub async fn verify_cashu_token_p2pk(
         .check_proofs_spent(proofs.clone())
         .await
         .map_err(|e| {
-            CashuError::Internal(format!("Failed to verify proof state with mint: {:?}", e))
+            CashuError::Internal(format!("Failed to verify proof state with mint: {}", e))
         })?;
 
     // Only Unspent is acceptable. Pending / Reserved / PendingSpent all mean the
@@ -1473,7 +1473,7 @@ pub async fn verify_cashu_token_p2pk(
         .iter()
         .map(|proof| {
             let y = proof.y().map_err(|e| {
-                CashuError::Internal(format!("Failed to compute proof y-coordinate: {:?}", e))
+                CashuError::Internal(format!("Failed to compute proof y-coordinate: {}", e))
             })?;
             Ok(ProofInfo {
                 proof: proof.clone(),
@@ -1540,7 +1540,7 @@ pub async fn verify_cashu_token_p2pk(
             crate::release_cashu_token(&proof_replay_key);
         }
         return Err(CashuError::Internal(format!(
-            "Failed to store proofs in database: {:?}",
+            "Failed to store proofs in database: {}",
             e
         )));
     }
@@ -2121,7 +2121,7 @@ pub async fn redeem_to_lightning() -> Result<bool, String> {
                     let mut signed_proofs = proofs_to_melt.clone();
                     for proof in &mut signed_proofs {
                         if let Err(e) = proof.sign_p2pk(private_key.clone()) {
-                            error!("❌ Failed to sign proof: {:?}", e);
+                            error!("❌ Failed to sign proof: {}", e);
                         }
                     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -407,8 +407,8 @@ pub async fn get_or_create_lnurl_client(
             Ok(client_arc)
         }
         Err(e) => {
-            error!("❌ Failed to create LNURL client for {}: {:?}", addr, e);
-            Err(format!("Failed to create LNURL client: {:?}", e))
+            error!("❌ Failed to create LNURL client for {}: {}", addr, e);
+            Err(format!("Failed to create LNURL client: {}", e))
         }
     }
 }
@@ -1041,7 +1041,7 @@ impl L402Module {
                     match ln_client_conn.generate_invoice(ln_invoice).await {
                         Ok(result) => result,
                         Err(e) => {
-                            error!("❌ Error generating invoice via LNURL {}: {:?}", addr, e);
+                            error!("❌ Error generating invoice via LNURL {}: {}", addr, e);
                             return None;
                         }
                     }
@@ -1078,7 +1078,7 @@ impl L402Module {
             match ln_client_conn.generate_invoice(ln_invoice).await {
                 Ok(result) => result,
                 Err(e) => {
-                    error!("❌ Error generating invoice: {:?}", e);
+                    error!("❌ Error generating invoice: {}", e);
                     return None;
                 }
             }
@@ -2420,7 +2420,7 @@ pub fn l402_access_handler(
                         ));
                     }
                     Err(e) => {
-                        warn!("⚠️ L402 auto-detect verification failed: {:?}", e);
+                        warn!("⚠️ L402 auto-detect verification failed: {}", e);
                         return 401;
                     }
                 }
@@ -2461,13 +2461,13 @@ pub fn l402_access_handler(
                             ));
                         }
                         Err(e) => {
-                            warn!("⚠️ L402 verification failed: {:?}", e);
+                            warn!("⚠️ L402 verification failed: {}", e);
                             return 401;
                         }
                     }
                 }
                 Err(e) => {
-                    warn!("⚠️ Failed to parse L402 header: {:?}", e);
+                    warn!("⚠️ Failed to parse L402 header: {}", e);
                     return 401;
                 }
             }
@@ -2521,7 +2521,7 @@ pub unsafe extern "C" fn init_module(cycle: *mut ngx_cycle_s) -> isize {
     // libsodium's RNG is only thread-safe once initialised, and every 402 mints
     // a macaroon from multiple workers at once. Done here, before nginx forks.
     if let Err(e) = macaroon::initialize() {
-        error!("❌ Failed to initialize macaroon crypto: {:?}", e);
+        error!("❌ Failed to initialize macaroon crypto: {}", e);
         return -1;
     }
 


### PR DESCRIPTION
Debug prints every field of a derived impl recursively, so an error that ever captured a secret-bearing input would print it. Nothing does today; the protection was incidental rather than deliberate.

Follows the review on #174 .