### PR TITLE
fix(sec): give preimages the same in-process replay fallback as cashu

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2210,33 +2210,52 @@ jobs:
           source .github/scripts/ci-wait.sh
           echo "🔒 A configured Redis that is unreachable must refuse credentials, not fall back."
 
-          # The pool is a OnceLock built lazily per worker, so nginx has to be
-          # restarted *while* Redis is down for this to exercise anything: with a
-          # pool already built, pool.get() fails and the outage path is reached
-          # either way. Restarting is what puts a worker in the state where
-          # redis_pool() returns None with REDIS_URL still set — the case that
-          # used to be indistinguishable from "operator never configured Redis"
-          # and admitted the request with per-worker protection only.
-          docker stop redis
-          docker restart nginx-lnd
-          wait_http http://0.0.0.0:8000/ 200 90 || { docker logs nginx-lnd; exit 1; }
-
-          resp=$(curl -s -i -w "\n%{http_code}" --max-time 30 http://0.0.0.0:8000/protected) || true
+          # Buy the credential with Redis still up. The challenge path also calls
+          # redis_pool() (get_dynamic_config, and the invoice rate limit), so
+          # minting a 402 during the outage blocks on r2d2's connect wait and the
+          # invoice comes back empty. What is under test is the replay claim, not
+          # the challenge, so keep the outage window around the claim alone.
+          docker exec redis redis-cli flushall
+          resp=$(curl -s -i --max-time 30 http://0.0.0.0:8000/protected) || true
           inv=$(echo "$resp" | grep -i "WWW-Authenticate: L402" | grep -o 'invoice="[^"]*"' | cut -d'"' -f2)
           mac=$(echo "$resp" | grep -i "WWW-Authenticate: L402" | grep -o 'macaroon="[^"]*"' | cut -d'"' -f2)
+          if [ -z "$inv" ] || [ -z "$mac" ]; then
+            echo "FAIL: no L402 challenge to work with"
+            echo "$resp"
+            docker logs nginx-lnd
+            exit 1
+          fi
           ph=$(docker exec lndnode lncli -n regtest decodepayreq "$inv" | jq -r '.payment_hash')
           docker exec lndnode lncli -n regtest payinvoice -f "$inv"
+          sleep 5
           pre=$(docker exec lndnode lncli -n regtest listpayments \
             | jq -r --arg h "$ph" '.payments[] | select(.payment_hash == $h) | .payment_preimage')
+          if [ -z "$pre" ] || [ "$pre" = "null" ]; then
+            echo "FAIL: payment produced no preimage"
+            exit 1
+          fi
 
-          # 90s, not 30: r2d2's build() waits out connection_timeout (30s default)
-          # before reporting the pool cannot be built.
-          sc=$(curl -s -o /dev/null -w "%{http_code}" --max-time 90 \
+          # Now the outage. The pool is a OnceLock built lazily per worker, so
+          # nginx has to be restarted *while* Redis is down for this to exercise
+          # anything: with a pool already built, pool.get() fails and the outage
+          # path is reached either way. Restarting is what puts a worker in the
+          # state where redis_pool() returns None with REDIS_URL still set — the
+          # case that used to be indistinguishable from "operator never
+          # configured Redis" and admitted with per-worker protection only.
+          docker stop redis
+          docker restart nginx-lnd
+          wait_http http://0.0.0.0:8000/ 200 90 || { docker start redis; docker logs nginx-lnd; exit 1; }
+
+          # Generous: the auth path calls redis_pool() twice (is_preimage_used,
+          # then the claim) and each waits out r2d2's 30s connection_timeout
+          # before reporting that the pool cannot be built.
+          sc=$(curl -s -o /dev/null -w "%{http_code}" --max-time 180 \
             -H "Authorization: L402 $mac:$pre" http://0.0.0.0:8000/protected) || true
           sc=${sc:-000}
           if [ "$sc" -ne 503 ]; then
             echo "FAIL: paid request during a Redis outage returned $sc, expected 503."
             echo "200 means the outage was treated as 'Redis never configured' and replay protection silently degraded."
+            echo "000 means curl gave up — the request was still blocked on the Redis connect wait."
             docker logs nginx-lnd
             docker start redis
             exit 1

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2100,6 +2100,51 @@ jobs:
           CASHU_WHITELISTED_MINTS: http://cashu-mint:3338
           CASHU_WALLET_MNEMONIC: "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about"
 
+      - name: Run Integration test - Redis configured but down fails closed
+        run: |
+          source .github/scripts/ci-wait.sh
+          echo "🔒 A configured Redis that is unreachable must refuse credentials, not fall back."
+
+          # The pool is a OnceLock built lazily per worker, so nginx has to be
+          # restarted *while* Redis is down for this to exercise anything: with a
+          # pool already built, pool.get() fails and the outage path is reached
+          # either way. Restarting is what puts a worker in the state where
+          # redis_pool() returns None with REDIS_URL still set — the case that
+          # used to be indistinguishable from "operator never configured Redis"
+          # and admitted the request with per-worker protection only.
+          docker stop redis
+          docker restart nginx-lnd
+          wait_http http://0.0.0.0:8000/ 200 90 || { docker logs nginx-lnd; exit 1; }
+
+          resp=$(curl -s -i -w "\n%{http_code}" --max-time 30 http://0.0.0.0:8000/protected) || true
+          inv=$(echo "$resp" | grep -i "WWW-Authenticate: L402" | grep -o 'invoice="[^"]*"' | cut -d'"' -f2)
+          mac=$(echo "$resp" | grep -i "WWW-Authenticate: L402" | grep -o 'macaroon="[^"]*"' | cut -d'"' -f2)
+          ph=$(docker exec lndnode lncli -n regtest decodepayreq "$inv" | jq -r '.payment_hash')
+          docker exec lndnode lncli -n regtest payinvoice -f "$inv"
+          pre=$(docker exec lndnode lncli -n regtest listpayments \
+            | jq -r --arg h "$ph" '.payments[] | select(.payment_hash == $h) | .payment_preimage')
+
+          # 90s, not 30: r2d2's build() waits out connection_timeout (30s default)
+          # before reporting the pool cannot be built.
+          sc=$(curl -s -o /dev/null -w "%{http_code}" --max-time 90 \
+            -H "Authorization: L402 $mac:$pre" http://0.0.0.0:8000/protected) || true
+          sc=${sc:-000}
+          if [ "$sc" -ne 503 ]; then
+            echo "FAIL: paid request during a Redis outage returned $sc, expected 503."
+            echo "200 means the outage was treated as 'Redis never configured' and replay protection silently degraded."
+            docker logs nginx-lnd
+            docker start redis
+            exit 1
+          fi
+          echo "PASS: request refused with 503 while Redis was down"
+
+          docker start redis
+          wait_container redis 60 || { docker logs redis; exit 1; }
+          docker restart nginx-lnd
+          wait_http http://0.0.0.0:8000/ 200 90 || { docker logs nginx-lnd; exit 1; }
+          docker exec redis redis-cli flushall
+          echo "✅ Redis and nginx restored for the sections that follow."
+
       - name: Run Integration Tests - Invoice Rate Limiting
         run: |
           echo "Testing Redis-based invoice rate limiting (l402_invoice_rate_limit)..."

--- a/.ngit/act/workflows/tests.yml
+++ b/.ngit/act/workflows/tests.yml
@@ -2208,33 +2208,52 @@ jobs:
           source .github/scripts/ci-wait.sh
           echo "🔒 A configured Redis that is unreachable must refuse credentials, not fall back."
 
-          # The pool is a OnceLock built lazily per worker, so nginx has to be
-          # restarted *while* Redis is down for this to exercise anything: with a
-          # pool already built, pool.get() fails and the outage path is reached
-          # either way. Restarting is what puts a worker in the state where
-          # redis_pool() returns None with REDIS_URL still set — the case that
-          # used to be indistinguishable from "operator never configured Redis"
-          # and admitted the request with per-worker protection only.
-          docker stop redis
-          docker restart nginx-lnd
-          wait_http http://0.0.0.0:8000/ 200 90 || { docker logs nginx-lnd; exit 1; }
-
-          resp=$(curl -s -i -w "\n%{http_code}" --max-time 30 http://0.0.0.0:8000/protected) || true
+          # Buy the credential with Redis still up. The challenge path also calls
+          # redis_pool() (get_dynamic_config, and the invoice rate limit), so
+          # minting a 402 during the outage blocks on r2d2's connect wait and the
+          # invoice comes back empty. What is under test is the replay claim, not
+          # the challenge, so keep the outage window around the claim alone.
+          docker exec redis redis-cli flushall
+          resp=$(curl -s -i --max-time 30 http://0.0.0.0:8000/protected) || true
           inv=$(echo "$resp" | grep -i "WWW-Authenticate: L402" | grep -o 'invoice="[^"]*"' | cut -d'"' -f2)
           mac=$(echo "$resp" | grep -i "WWW-Authenticate: L402" | grep -o 'macaroon="[^"]*"' | cut -d'"' -f2)
+          if [ -z "$inv" ] || [ -z "$mac" ]; then
+            echo "FAIL: no L402 challenge to work with"
+            echo "$resp"
+            docker logs nginx-lnd
+            exit 1
+          fi
           ph=$(docker exec lndnode lncli -n regtest decodepayreq "$inv" | jq -r '.payment_hash')
           docker exec lndnode lncli -n regtest payinvoice -f "$inv"
+          sleep 5
           pre=$(docker exec lndnode lncli -n regtest listpayments \
             | jq -r --arg h "$ph" '.payments[] | select(.payment_hash == $h) | .payment_preimage')
+          if [ -z "$pre" ] || [ "$pre" = "null" ]; then
+            echo "FAIL: payment produced no preimage"
+            exit 1
+          fi
 
-          # 90s, not 30: r2d2's build() waits out connection_timeout (30s default)
-          # before reporting the pool cannot be built.
-          sc=$(curl -s -o /dev/null -w "%{http_code}" --max-time 90 \
+          # Now the outage. The pool is a OnceLock built lazily per worker, so
+          # nginx has to be restarted *while* Redis is down for this to exercise
+          # anything: with a pool already built, pool.get() fails and the outage
+          # path is reached either way. Restarting is what puts a worker in the
+          # state where redis_pool() returns None with REDIS_URL still set — the
+          # case that used to be indistinguishable from "operator never
+          # configured Redis" and admitted with per-worker protection only.
+          docker stop redis
+          docker restart nginx-lnd
+          wait_http http://0.0.0.0:8000/ 200 90 || { docker start redis; docker logs nginx-lnd; exit 1; }
+
+          # Generous: the auth path calls redis_pool() twice (is_preimage_used,
+          # then the claim) and each waits out r2d2's 30s connection_timeout
+          # before reporting that the pool cannot be built.
+          sc=$(curl -s -o /dev/null -w "%{http_code}" --max-time 180 \
             -H "Authorization: L402 $mac:$pre" http://0.0.0.0:8000/protected) || true
           sc=${sc:-000}
           if [ "$sc" -ne 503 ]; then
             echo "FAIL: paid request during a Redis outage returned $sc, expected 503."
             echo "200 means the outage was treated as 'Redis never configured' and replay protection silently degraded."
+            echo "000 means curl gave up — the request was still blocked on the Redis connect wait."
             docker logs nginx-lnd
             docker start redis
             exit 1

--- a/.ngit/act/workflows/tests.yml
+++ b/.ngit/act/workflows/tests.yml
@@ -2203,6 +2203,51 @@ jobs:
           CASHU_WHITELISTED_MINTS: http://cashu-mint:3338
           CASHU_WALLET_MNEMONIC: "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about"
 
+      - name: Run Integration test - Redis configured but down fails closed
+        run: |
+          source .github/scripts/ci-wait.sh
+          echo "🔒 A configured Redis that is unreachable must refuse credentials, not fall back."
+
+          # The pool is a OnceLock built lazily per worker, so nginx has to be
+          # restarted *while* Redis is down for this to exercise anything: with a
+          # pool already built, pool.get() fails and the outage path is reached
+          # either way. Restarting is what puts a worker in the state where
+          # redis_pool() returns None with REDIS_URL still set — the case that
+          # used to be indistinguishable from "operator never configured Redis"
+          # and admitted the request with per-worker protection only.
+          docker stop redis
+          docker restart nginx-lnd
+          wait_http http://0.0.0.0:8000/ 200 90 || { docker logs nginx-lnd; exit 1; }
+
+          resp=$(curl -s -i -w "\n%{http_code}" --max-time 30 http://0.0.0.0:8000/protected) || true
+          inv=$(echo "$resp" | grep -i "WWW-Authenticate: L402" | grep -o 'invoice="[^"]*"' | cut -d'"' -f2)
+          mac=$(echo "$resp" | grep -i "WWW-Authenticate: L402" | grep -o 'macaroon="[^"]*"' | cut -d'"' -f2)
+          ph=$(docker exec lndnode lncli -n regtest decodepayreq "$inv" | jq -r '.payment_hash')
+          docker exec lndnode lncli -n regtest payinvoice -f "$inv"
+          pre=$(docker exec lndnode lncli -n regtest listpayments \
+            | jq -r --arg h "$ph" '.payments[] | select(.payment_hash == $h) | .payment_preimage')
+
+          # 90s, not 30: r2d2's build() waits out connection_timeout (30s default)
+          # before reporting the pool cannot be built.
+          sc=$(curl -s -o /dev/null -w "%{http_code}" --max-time 90 \
+            -H "Authorization: L402 $mac:$pre" http://0.0.0.0:8000/protected) || true
+          sc=${sc:-000}
+          if [ "$sc" -ne 503 ]; then
+            echo "FAIL: paid request during a Redis outage returned $sc, expected 503."
+            echo "200 means the outage was treated as 'Redis never configured' and replay protection silently degraded."
+            docker logs nginx-lnd
+            docker start redis
+            exit 1
+          fi
+          echo "PASS: request refused with 503 while Redis was down"
+
+          docker start redis
+          wait_container redis 60 || { docker logs redis; exit 1; }
+          docker restart nginx-lnd
+          wait_http http://0.0.0.0:8000/ 200 90 || { docker logs nginx-lnd; exit 1; }
+          docker exec redis redis-cli flushall
+          echo "✅ Redis and nginx restored for the sections that follow."
+
       - name: Run Integration Tests - Invoice Rate Limiting
         run: |
           echo "Testing Redis-based invoice rate limiting (l402_invoice_rate_limit)..."

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,3 +44,8 @@ libc = "0.2.189"
 [features]
 default = []
 export-modules = []
+
+# Do NOT add `panic = "abort"` to any profile here. The FFI boundary relies on
+# catch_unwind to stop a panic unwinding into nginx's C stack; with abort, a
+# panic in one request kills the whole worker instead of returning 500. The
+# guards fail silently — nothing warns you they stopped working.

--- a/docs/config-env-vars.md
+++ b/docs/config-env-vars.md
@@ -98,6 +98,14 @@ Environment=ROOT_KEY=your-root-key
 > in-process caching only — it is lost on restart and does not work across
 > multiple nginx workers. Multi-worker deployments **require** Redis.
 
+> **Not configuring Redis and Redis being down are different.** Leaving
+> `REDIS_URL` unset is a choice, and the module degrades to the per-worker cache
+> above. A `REDIS_URL` that is set but unreachable is an outage: paid credentials
+> are refused with **503** until Redis returns, rather than admitted under weaker
+> protection. Replay protection is the one thing that cannot fail open, since an
+> attacker who can take Redis down would otherwise get unlimited reuse of a
+> single payment.
+
 ```bash
 Environment=REDIS_URL=redis://127.0.0.1:6379
 

--- a/ngx_l402_core/src/lib.rs
+++ b/ngx_l402_core/src/lib.rs
@@ -15,6 +15,7 @@ mod l402_header;
 mod p2pk;
 mod rate_limit;
 mod redact;
+mod replay_cache;
 mod wallet_seed;
 
 pub use cashu_error::CashuError;
@@ -24,6 +25,7 @@ pub use l402_header::parse_l402_header_value;
 pub use p2pk::{parse_p2pk_secret_key, InvalidP2pkKey};
 pub use rate_limit::parse_rate_limit;
 pub use redact::redact_redis_url;
+pub use replay_cache::{ReplayCache, DEFAULT_REPLAY_CACHE_CAP};
 pub use wallet_seed::{
     derive_wallet_seed, generate_mnemonic, is_valid_mnemonic, wallet_fingerprint, InvalidMnemonic,
     WALLET_SEED_LEN,

--- a/ngx_l402_core/src/replay_cache.rs
+++ b/ngx_l402_core/src/replay_cache.rs
@@ -1,0 +1,170 @@
+//! Bounded in-process replay cache — the fallback used when Redis is absent.
+//!
+//! Redis is the authoritative, cross-worker replay gate. When it is not
+//! configured, each worker falls back to this: single-worker protection, which
+//! is what the documentation promises operators who run without Redis.
+//!
+//! Eviction is FIFO, not a flush. Clearing the whole set at capacity would let
+//! an attacker push `cap` fresh credentials through and then replay an older
+//! one, which defeats the purpose of keeping the set at all.
+
+use std::collections::{HashSet, VecDeque};
+
+/// Default number of entries held per worker.
+pub const DEFAULT_REPLAY_CACHE_CAP: usize = 10_000;
+
+/// A bounded set of already-spent credential keys.
+///
+/// Keys are opaque strings — callers pass a *hash* of the credential (see
+/// `preimage_redis_key`), never the raw secret, so the cache holds nothing
+/// worth stealing.
+#[derive(Debug)]
+pub struct ReplayCache {
+    seen: HashSet<String>,
+    order: VecDeque<String>,
+    cap: usize,
+}
+
+impl ReplayCache {
+    /// Create a cache holding at most `cap` entries. A `cap` of 0 is raised to
+    /// 1: a zero-capacity cache would admit every replay.
+    pub fn with_capacity(cap: usize) -> Self {
+        let cap = cap.max(1);
+        Self {
+            seen: HashSet::with_capacity(cap),
+            order: VecDeque::with_capacity(cap),
+            cap,
+        }
+    }
+
+    /// Claim `key`. Returns `true` on first sighting (caller may admit) and
+    /// `false` if it was already claimed (caller must reject as a replay).
+    ///
+    /// At capacity the oldest entry is evicted, so a credential can only be
+    /// replayed after `cap` distinct others have been seen — the bound the
+    /// operator accepts by running without Redis.
+    pub fn claim(&mut self, key: &str) -> bool {
+        if self.seen.contains(key) {
+            return false;
+        }
+        if self.order.len() >= self.cap {
+            if let Some(oldest) = self.order.pop_front() {
+                self.seen.remove(&oldest);
+            }
+        }
+        self.order.push_back(key.to_string());
+        self.seen.insert(key.to_string());
+        true
+    }
+
+    /// Whether `key` has been claimed. Read-only; does not claim.
+    pub fn contains(&self, key: &str) -> bool {
+        self.seen.contains(key)
+    }
+
+    /// Number of entries currently held.
+    pub fn len(&self) -> usize {
+        self.order.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.order.is_empty()
+    }
+}
+
+impl Default for ReplayCache {
+    fn default() -> Self {
+        Self::with_capacity(DEFAULT_REPLAY_CACHE_CAP)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn first_claim_succeeds_and_second_is_a_replay() {
+        let mut c = ReplayCache::with_capacity(8);
+        assert!(c.claim("a"), "first sighting must be admitted");
+        assert!(!c.claim("a"), "second sighting must be rejected");
+    }
+
+    #[test]
+    fn distinct_keys_do_not_collide() {
+        let mut c = ReplayCache::with_capacity(8);
+        assert!(c.claim("a"));
+        assert!(c.claim("b"));
+        assert!(!c.claim("a"));
+        assert!(!c.claim("b"));
+    }
+
+    #[test]
+    fn contains_does_not_claim() {
+        let mut c = ReplayCache::with_capacity(4);
+        assert!(!c.contains("a"));
+        assert!(c.claim("a"));
+        assert!(c.contains("a"));
+        assert_eq!(c.len(), 1);
+    }
+
+    #[test]
+    fn stays_within_capacity() {
+        let mut c = ReplayCache::with_capacity(4);
+        for i in 0..100 {
+            c.claim(&format!("k{i}"));
+        }
+        assert_eq!(c.len(), 4, "cache must not grow past its capacity");
+    }
+
+    /// The property that matters: eviction drops the OLDEST entry, so recent
+    /// credentials stay protected. A flush-at-capacity implementation fails
+    /// this — after the flush every earlier key is replayable again.
+    #[test]
+    fn eviction_is_fifo_not_a_flush() {
+        let mut c = ReplayCache::with_capacity(3);
+        c.claim("oldest");
+        c.claim("middle");
+        c.claim("newest");
+
+        c.claim("overflow"); // evicts "oldest" only
+
+        assert!(!c.contains("oldest"), "oldest should have been evicted");
+        assert!(c.contains("middle"), "middle must survive");
+        assert!(c.contains("newest"), "newest must survive");
+        assert!(c.contains("overflow"));
+        assert!(!c.claim("newest"), "a surviving key is still a replay");
+    }
+
+    /// A flush-at-capacity cache lets an attacker push `cap` throwaway
+    /// credentials and then reuse a spent one. FIFO makes that cost linear in
+    /// the number of *later* credentials rather than resetting the whole set.
+    #[test]
+    fn flooding_evicts_gradually_rather_than_resetting() {
+        let mut c = ReplayCache::with_capacity(10);
+        c.claim("spent");
+
+        for i in 0..9 {
+            c.claim(&format!("filler{i}"));
+        }
+        assert!(
+            !c.claim("spent"),
+            "still protected while it remains resident"
+        );
+
+        c.claim("filler9");
+        assert!(!c.contains("spent"));
+    }
+
+    #[test]
+    fn zero_capacity_is_raised_to_one() {
+        let mut c = ReplayCache::with_capacity(0);
+        assert!(c.claim("a"));
+        assert!(!c.claim("a"), "a zero-cap cache must not admit replays");
+    }
+
+    #[test]
+    fn default_uses_the_documented_capacity() {
+        assert_eq!(ReplayCache::default().len(), 0);
+        assert_eq!(DEFAULT_REPLAY_CACHE_CAP, 10_000);
+    }
+}

--- a/ngx_l402_core/src/replay_cache.rs
+++ b/ngx_l402_core/src/replay_cache.rs
@@ -62,6 +62,17 @@ impl ReplayCache {
         self.seen.contains(key)
     }
 
+    /// Undo a claim, so a credential whose guarded work then failed can be
+    /// retried instead of being stuck "used". Mirrors the Redis path's
+    /// `release_cashu_token`; a key that was never claimed is left alone.
+    pub fn release(&mut self, key: &str) {
+        if self.seen.remove(key) {
+            if let Some(pos) = self.order.iter().position(|k| k == key) {
+                self.order.remove(pos);
+            }
+        }
+    }
+
     /// Number of entries currently held.
     pub fn len(&self) -> usize {
         self.order.len()
@@ -166,5 +177,39 @@ mod tests {
     fn default_uses_the_documented_capacity() {
         assert_eq!(ReplayCache::default().len(), 0);
         assert_eq!(DEFAULT_REPLAY_CACHE_CAP, 10_000);
+    }
+
+    #[test]
+    fn release_lets_a_failed_claim_be_retried() {
+        let mut c = ReplayCache::with_capacity(8);
+        assert!(c.claim("a"));
+        c.release("a");
+        assert!(!c.contains("a"));
+        assert!(c.claim("a"), "a released key must be claimable again");
+    }
+
+    /// Release must drop the key from the FIFO order too, or the freed slot
+    /// stays occupied and eviction pushes out a still-live entry early.
+    #[test]
+    fn release_frees_the_capacity_slot() {
+        let mut c = ReplayCache::with_capacity(2);
+        assert!(c.claim("a"));
+        assert!(c.claim("b"));
+        c.release("a");
+        assert_eq!(c.len(), 1);
+        assert!(c.claim("c"));
+        assert!(
+            c.contains("b"),
+            "b must survive — a's slot was the free one"
+        );
+    }
+
+    #[test]
+    fn releasing_an_unclaimed_key_is_a_no_op() {
+        let mut c = ReplayCache::with_capacity(4);
+        assert!(c.claim("a"));
+        c.release("never-claimed");
+        assert_eq!(c.len(), 1);
+        assert!(c.contains("a"));
     }
 }

--- a/src/cashu.rs
+++ b/src/cashu.rs
@@ -13,9 +13,14 @@ use std::sync::{Arc, OnceLock};
 use tokio::runtime::Runtime;
 use url::Url;
 
-// Thread-local storage to track processed tokens
+// Per-worker replay cache for Cashu tokens, used when Redis is not configured.
+// Shares `ngx_l402_core::ReplayCache` with the preimage path so both credential
+// types get the same bounded, FIFO-evicting protection: dropping the whole set
+// at capacity would let an attacker push `cap` fresh tokens through and then
+// replay an older one.
 thread_local! {
-    static PROCESSED_TOKENS: RefCell<Option<HashSet<String>>> = const { RefCell::new(None) };
+    static PROCESSED_TOKENS: RefCell<ngx_l402_core::ReplayCache> =
+        RefCell::new(ngx_l402_core::ReplayCache::default());
 }
 
 const MSAT_PER_SAT: u64 = 1000;
@@ -193,10 +198,6 @@ async fn get_or_create_wallet(
     let mut guard = cache.write().await;
     Ok(guard.entry(key).or_insert(wallet).clone())
 }
-
-/// Maximum number of entries in the thread-local PROCESSED_TOKENS cache.
-/// When exceeded, the set is cleared. Redis remains the authoritative replay check.
-const MAX_PROCESSED_TOKENS: usize = 10_000;
 
 /// Number of words in a freshly generated wallet mnemonic. 12 words = 128 bits
 /// of entropy (the common Cashu default).
@@ -469,19 +470,11 @@ fn persist_fingerprint(path: &str, fingerprint: &str) -> Result<(), String> {
     Ok(())
 }
 
-/// Add token to thread-local cache, clearing if at capacity.
+/// Record a token as spent in the per-worker cache. Eviction is FIFO, so at
+/// capacity only the oldest entry is dropped and recent tokens stay protected.
 fn cache_processed_token(token: &str) {
     PROCESSED_TOKENS.with(|tokens| {
-        if let Some(set) = tokens.borrow_mut().as_mut() {
-            if set.len() >= MAX_PROCESSED_TOKENS {
-                debug!(
-                    "🔄 PROCESSED_TOKENS cache at capacity ({}), clearing",
-                    MAX_PROCESSED_TOKENS
-                );
-                set.clear();
-            }
-            set.insert(token.to_string());
-        }
+        tokens.borrow_mut().claim(token);
     });
 }
 
@@ -583,10 +576,8 @@ pub fn initialize_ln_client(client_type: String) -> Result<(), String> {
 }
 
 pub fn initialize_cashu(db_url: &str) -> Result<(), String> {
-    // Initialize PROCESSED_TOKENS with empty HashSet
-    PROCESSED_TOKENS.with(|tokens| {
-        *tokens.borrow_mut() = Some(HashSet::new());
-    });
+    // PROCESSED_TOKENS needs no init — the thread-local is created empty on
+    // first use in whichever worker touches it.
 
     // Set Cashu eCash enabled flag
     let _ = CASHU_ECASH_ENABLED.set(true);
@@ -1025,13 +1016,7 @@ pub async fn verify_cashu_token(
     debug!("🔍 Verifying Cashu token, checking database connection...");
 
     // Check thread-local memory cache first (fastest path — no I/O)
-    let token_already_processed = PROCESSED_TOKENS.with(|tokens| {
-        if let Some(set) = tokens.borrow().as_ref() {
-            set.contains(token)
-        } else {
-            false
-        }
-    });
+    let token_already_processed = PROCESSED_TOKENS.with(|tokens| tokens.borrow().contains(token));
 
     if token_already_processed {
         warn!("🚨 Replay attack detected: Cashu token already used (memory cache)");
@@ -1214,12 +1199,7 @@ pub async fn verify_cashu_token_p2pk(
     info!("🔐 P2PK mode: Optimized token verification");
 
     // Check thread-local memory cache first (fastest path — no I/O)
-    let token_seen = PROCESSED_TOKENS.with(|tokens| {
-        tokens
-            .borrow()
-            .as_ref()
-            .is_some_and(|set| set.contains(token))
-    });
+    let token_seen = PROCESSED_TOKENS.with(|tokens| tokens.borrow().contains(token));
 
     if token_seen {
         warn!("🚨 Replay attack detected: Cashu token already used (memory cache)");

--- a/src/cashu.rs
+++ b/src/cashu.rs
@@ -1485,9 +1485,21 @@ pub async fn verify_cashu_token_p2pk(
         }
         Ok(true) => true, // won the race — proceed to persist proofs
         Err(crate::ReplayClaimError::NotConfigured) => {
-            // Redis was never configured — an explicit operator choice. Fall
-            // back to the in-process memory cache (single-worker protection).
+            // Redis was never configured — an explicit operator choice. Claim in
+            // the per-worker cache instead, and claim by *proof key*: the raw
+            // token check at the top of this function cannot see the same proofs
+            // re-encoded into a different string, and this path stores proofs
+            // without a mint swap, so nothing downstream catches it either
+            // (`update_proofs` upserts on a conflicting Y value rather than
+            // failing). Without this claim a re-encoded token is served free,
+            // repeatedly.
             warn!("⚠️ Redis not configured — Cashu replay protection is in-process only (single-worker)");
+            if !PROCESSED_TOKENS.with(|t| t.borrow_mut().claim(&proof_replay_key)) {
+                error!("🚨 Replay attack detected: proof set already used (in-process cache)");
+                return Err(CashuError::BadCredential(
+                    "Cashu token already used".to_string(),
+                ));
+            }
             false
         }
         Err(crate::ReplayClaimError::Unavailable(e)) => {
@@ -1511,13 +1523,14 @@ pub async fn verify_cashu_token_p2pk(
     // Store directly in database using update_proofs (same as receive_proofs does internally)
     // Pass empty vec for second parameter (no proofs to delete)
     if let Err(e) = wallet.localstore.update_proofs(proof_infos, vec![]).await {
-        // The DB write failed after we took the replay claim. Release the claim
-        // so the token isn't stuck "used" — otherwise a legitimate retry would
-        // be rejected until the Redis TTL expires even though no proofs were
-        // ever persisted. (Only release if we actually claimed; the fail-open
-        // branch above holds no claim to release.)
+        // The DB write failed after we took the replay claim. Release it so the
+        // token isn't stuck "used" — otherwise a legitimate retry would be
+        // rejected even though no proofs were ever persisted. Whichever store
+        // holds the claim is the one to release.
         if claimed {
             crate::release_cashu_token(&proof_replay_key);
+        } else {
+            PROCESSED_TOKENS.with(|t| t.borrow_mut().release(&proof_replay_key));
         }
         return Err(CashuError::Internal(format!(
             "Failed to store proofs in database: {:?}",
@@ -1531,9 +1544,10 @@ pub async fn verify_cashu_token_p2pk(
         }
     }
 
-    // Cache both the raw token string and the proof-based key so that both
-    // exact-string and re-encoded replay attempts are caught on the fast
-    // thread-local path without a Redis round-trip.
+    // Cache the raw token so an identical resubmission short-circuits at the top
+    // of this function without touching Redis. The proof key is claimed above
+    // when Redis is absent; claiming it again here is a no-op that keeps both
+    // paths writing the same two entries.
     cache_processed_token(&proof_replay_key);
     cache_processed_token(token);
     info!(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -480,6 +480,25 @@ impl std::fmt::Display for ReplayClaimError {
     }
 }
 
+/// Why `redis_pool()` returned `None`. It collapses two cases a replay path must
+/// not treat alike: `REDIS_URL` was never set, or it was set and the pool could
+/// not be built. The second is an outage — r2d2's `build()` calls
+/// `wait_for_initialization()`, so it returns `Ok` only once a connection is
+/// actually established — and anyone who can take Redis down can induce it.
+/// Falling back to per-worker protection there would unlock replay on demand.
+///
+/// A *malformed* `REDIS_URL` also lands on `NotConfigured`: `RedisClient::open`
+/// only parses, so it fails at boot with an error log and the module never has
+/// Redis at all. That is a startup mistake to fix, not an attacker-inducible
+/// transition out of a working state.
+fn redis_absence_reason() -> ReplayClaimError {
+    if REDIS_URL.get().is_some() {
+        ReplayClaimError::Unavailable("configured, but the pool could not be built".to_string())
+    } else {
+        ReplayClaimError::NotConfigured
+    }
+}
+
 /// Map an atomic preimage replay-claim to the nginx access-phase return code.
 /// Centralizes the configured-vs-unreachable Redis policy so the auto-detect and
 /// classic verification paths stay consistent:
@@ -528,12 +547,17 @@ fn store_preimage_as_used(
     let redis_key = preimage_redis_key(preimage);
 
     // No Redis is an operator's deliberate choice: degrade to per-worker
-    // protection, as the Cashu path does. A *configured* Redis that is
-    // unreachable still fails closed below — that case is attacker-inducible
-    // and must not unlock replay.
+    // protection, as the Cashu path does. A *configured* Redis that cannot be
+    // reached fails closed instead — that case is attacker-inducible and must
+    // not unlock replay.
     let Some(pool) = redis_pool() else {
-        warn_replay_is_in_process_only();
-        return Ok(PREIMAGE_CACHE.with(|c| c.borrow_mut().claim(&redis_key)));
+        return match redis_absence_reason() {
+            ReplayClaimError::NotConfigured => {
+                warn_replay_is_in_process_only();
+                Ok(PREIMAGE_CACHE.with(|c| c.borrow_mut().claim(&redis_key)))
+            }
+            e => Err(e),
+        };
     };
 
     let mut conn = pool
@@ -617,7 +641,9 @@ pub fn is_cashu_token_used(token: &str) -> bool {
 /// Atomically store a Cashu token as used via SET NX EX (single round-trip).
 /// Called ONLY after successful verification to avoid burning tokens on transient failures.
 pub fn store_cashu_token_as_used(token: &str) -> Result<bool, ReplayClaimError> {
-    let pool = redis_pool().ok_or(ReplayClaimError::NotConfigured)?;
+    let Some(pool) = redis_pool() else {
+        return Err(redis_absence_reason());
+    };
 
     let mut conn = pool
         .get()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -419,15 +419,40 @@ pub async fn get_or_create_lnurl_client(
 /// the true gate and closes the TOCTOU window between concurrent workers.
 /// Fails open (returns false) if Redis is unavailable.
 fn is_preimage_used(preimage: &[u8]) -> bool {
+    let redis_key = preimage_redis_key(preimage);
     let Some(pool) = redis_pool() else {
-        return false;
+        return PREIMAGE_CACHE.with(|c| c.borrow().contains(&redis_key));
     };
     let mut conn = match pool.get() {
         Ok(c) => c,
         Err(_) => return false,
     };
-    let redis_key = preimage_redis_key(preimage);
     conn.exists::<_, bool>(&redis_key).unwrap_or(false)
+}
+
+// Per-worker replay cache, used when Redis is not configured. Redis is the
+// authoritative cross-worker gate; this is the single-worker fallback the docs
+// promise operators who run without it. Mirrors the Cashu path's
+// PROCESSED_TOKENS, and holds the hashed key rather than the raw preimage so no
+// payment secret outlives the request.
+thread_local! {
+    static PREIMAGE_CACHE: std::cell::RefCell<ngx_l402_core::ReplayCache> =
+        std::cell::RefCell::new(ngx_l402_core::ReplayCache::default());
+}
+
+/// Warn once per worker that replay protection is degraded, rather than on
+/// every request.
+static NO_REDIS_REPLAY_REPORTED: std::sync::atomic::AtomicBool =
+    std::sync::atomic::AtomicBool::new(false);
+
+fn warn_replay_is_in_process_only() {
+    if !NO_REDIS_REPLAY_REPORTED.swap(true, std::sync::atomic::Ordering::Relaxed) {
+        warn!(
+            "⚠️ Redis not configured — preimage replay protection is per-worker, bounded to \
+             {} entries, and lost on reload. Multi-worker deployments require Redis.",
+            ngx_l402_core::DEFAULT_REPLAY_CACHE_CAP
+        );
+    }
 }
 
 /// Why an atomic replay-claim (`store_*_as_used`) did not produce a definitive
@@ -459,18 +484,21 @@ impl std::fmt::Display for ReplayClaimError {
 /// Centralizes the configured-vs-unreachable Redis policy so the auto-detect and
 /// classic verification paths stay consistent:
 ///   - claimed (first use)       -> admit (NGX_DECLINED)
-///   - already claimed (race)    -> reject as replay (401)
-///   - Redis not configured      -> admit; in-process protection only
+///   - already claimed           -> reject as replay (401)
 ///   - Redis configured but down -> fail closed (503) to prevent replay
+///
+/// `store_preimage_as_used` resolves an unconfigured Redis itself, against the
+/// per-worker cache, so `NotConfigured` does not reach here from that path. The
+/// arm remains for other callers of the shared [`ReplayClaimError`].
 fn handle_preimage_claim(result: Result<bool, ReplayClaimError>) -> isize {
     match result {
         Ok(true) => NGX_DECLINED as isize,
         Ok(false) => {
-            warn!("🚨 Preimage already claimed by concurrent worker — replay rejected");
+            warn!("🚨 Preimage already claimed — replay rejected");
             401
         }
         Err(ReplayClaimError::NotConfigured) => {
-            warn!("⚠️ Redis not configured — replay protection is in-process only (single-worker)");
+            warn_replay_is_in_process_only();
             NGX_DECLINED as isize
         }
         Err(ReplayClaimError::Unavailable(e)) => {
@@ -497,13 +525,21 @@ fn store_preimage_as_used(
     preimage: &[u8],
     macaroon_timeout: i64,
 ) -> Result<bool, ReplayClaimError> {
-    let pool = redis_pool().ok_or(ReplayClaimError::NotConfigured)?;
+    let redis_key = preimage_redis_key(preimage);
+
+    // No Redis is an operator's deliberate choice: degrade to per-worker
+    // protection, as the Cashu path does. A *configured* Redis that is
+    // unreachable still fails closed below — that case is attacker-inducible
+    // and must not unlock replay.
+    let Some(pool) = redis_pool() else {
+        warn_replay_is_in_process_only();
+        return Ok(PREIMAGE_CACHE.with(|c| c.borrow_mut().claim(&redis_key)));
+    };
 
     let mut conn = pool
         .get()
         .map_err(|e| ReplayClaimError::Unavailable(format!("connection: {}", e)))?;
 
-    let redis_key = preimage_redis_key(preimage);
     // `None` = store without EX. Never-expiring macaroons need never-expiring
     // markers; the alternative is a guaranteed replay window once the TTL lapses.
     let ttl = if macaroon_timeout > 0 {


### PR DESCRIPTION
Without Redis the preimage path had no replay protection at all: is_preimage_used returned false, store_preimage_as_used returned NotConfigured, and the policy admitted.

Add a shared ReplayCache in ngx_l402_core and use it for both credential types. Eviction is FIFO rather than a flush: the Cashu cache cleared itself entirely at capacity, so an attacker could push 10k throwaway tokens through and then replay a spent one. Both paths now degrade to per-worker protection when Redis is unconfigured, and both still fail closed when a configured Redis is unreachable — that case is attacker-inducible and must not unlock replay.

The cache stores the hashed key, not the raw preimage, and the degraded-mode warning fires once per worker instead of once per request.

Also document why panic = "abort" must never be added to a profile: it silently turns every catch_unwind at the FFI boundary into a worker abort.