### PR TITLE
fix(security): refuse symlinks at the remaining privileged file operations

### DIFF
--- a/src/cashu.rs
+++ b/src/cashu.rs
@@ -294,10 +294,15 @@ fn resolve_wallet_mnemonic(db_url: &str) -> Result<(), String> {
 ///
 /// The master creates them as root; the workers that use them run as nginx.
 /// The data directory already names that user, so follow it.
+///
+/// Ownership and mode are applied to an `O_NOFOLLOW` descriptor, never to the
+/// path. This runs as root, so a path-based chown here is a privilege-
+/// escalation primitive: a symlink planted at `<db>-wal` would hand the link's
+/// target to the worker user with mode 0660.
 fn set_db_ownership(db_url: &str) {
     #[cfg(unix)]
     {
-        use std::os::unix::fs::{MetadataExt, PermissionsExt};
+        use std::os::unix::fs::{MetadataExt, OpenOptionsExt, PermissionsExt};
 
         let path = std::path::Path::new(
             db_url
@@ -318,10 +323,30 @@ fn set_db_ownership(db_url: &str) {
             if !file.exists() {
                 continue;
             }
+
+            // Read-only is enough: fchown/fchmod act on the descriptor, and
+            // opening the SQLite files this way does not disturb them.
+            let opened = std::fs::OpenOptions::new()
+                .read(true)
+                .custom_flags(libc::O_NOFOLLOW)
+                .open(&file);
+
+            let handle = match opened {
+                Ok(handle) => handle,
+                Err(e) => {
+                    warn!(
+                        "⚠️ Not adjusting ownership of {} (ELOOP = symlink, refused): {}",
+                        file.display(),
+                        e
+                    );
+                    continue;
+                }
+            };
+
             if let Some((uid, gid)) = owner {
-                let _ = std::os::unix::fs::chown(&file, Some(uid), Some(gid));
+                let _ = std::os::unix::fs::fchown(&handle, Some(uid), Some(gid));
             }
-            let _ = std::fs::set_permissions(&file, std::fs::Permissions::from_mode(0o660));
+            let _ = handle.set_permissions(std::fs::Permissions::from_mode(0o660));
         }
     }
     #[cfg(not(unix))]
@@ -365,25 +390,29 @@ fn wallet_mnemonic_file_path(db_url: &str) -> Option<String> {
 /// Persist the mnemonic to `path` with owner-only permissions where supported.
 ///
 /// On unix the file is created with mode 0600 up front, so it is never visible
-/// at the umask's default permissions.
+/// at the umask's default permissions, and `O_NOFOLLOW` refuses a symlink: this
+/// writes the BIP39 phrase controlling every Cashu fund, and `O_CREAT` alone
+/// follows an existing link, which would deliver it to the link's target.
 fn persist_mnemonic(path: &str, mnemonic: &str) -> Result<(), String> {
     #[cfg(unix)]
     {
         use std::io::Write;
-        use std::os::unix::fs::OpenOptionsExt;
+        use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
 
         let mut f = std::fs::OpenOptions::new()
             .write(true)
             .create(true)
             .truncate(true)
             .mode(0o600)
+            .custom_flags(libc::O_NOFOLLOW)
             .open(path)
-            .map_err(|e| format!("open {}: {}", path, e))?;
+            .map_err(|e| format!("open {} (ELOOP = symlink, refused): {}", path, e))?;
         f.write_all(format!("{}\n", mnemonic).as_bytes())
             .map_err(|e| format!("write {}: {}", path, e))?;
-        // An existing file keeps its own mode on open, so set it explicitly too.
-        use std::os::unix::fs::PermissionsExt;
-        let _ = std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600));
+        // An existing file keeps its own mode on open, so set it explicitly —
+        // on the descriptor, since a path-based call would follow a symlink
+        // swapped in after the open.
+        let _ = f.set_permissions(std::fs::Permissions::from_mode(0o600));
     }
     #[cfg(not(unix))]
     {
@@ -458,13 +487,34 @@ fn wallet_fingerprint_file_path(db_url: &str) -> Option<String> {
     )
 }
 
+/// Persist the wallet fingerprint beside the database.
+///
+/// `fs::write` and a path-based chmod both follow symlinks, and this runs as
+/// root in the master — a link planted here would redirect the write, and the
+/// chmod, onto an arbitrary file. Open with `O_NOFOLLOW` and set the mode on
+/// the descriptor instead.
 fn persist_fingerprint(path: &str, fingerprint: &str) -> Result<(), String> {
-    std::fs::write(path, format!("{}\n", fingerprint))
-        .map_err(|e| format!("write {}: {}", path, e))?;
     #[cfg(unix)]
     {
-        use std::os::unix::fs::PermissionsExt;
-        let _ = std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600));
+        use std::io::Write;
+        use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
+
+        let mut f = std::fs::OpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .mode(0o600)
+            .custom_flags(libc::O_NOFOLLOW)
+            .open(path)
+            .map_err(|e| format!("open {} (ELOOP = symlink, refused): {}", path, e))?;
+        f.write_all(format!("{}\n", fingerprint).as_bytes())
+            .map_err(|e| format!("write {}: {}", path, e))?;
+        let _ = f.set_permissions(std::fs::Permissions::from_mode(0o600));
+    }
+    #[cfg(not(unix))]
+    {
+        std::fs::write(path, format!("{}\n", fingerprint))
+            .map_err(|e| format!("write {}: {}", path, e))?;
     }
     Ok(())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2769,12 +2769,17 @@ fn start_cashu_redemption_in_worker(interval_secs: u64) {
         let _ = std::thread::Builder::new()
             .name("cashu_redeem_lease".into())
             .spawn(move || {
+                use std::os::unix::fs::OpenOptionsExt;
                 use std::os::unix::io::AsRawFd;
 
+                // O_NOFOLLOW: the lease lives beside the database, so a symlink
+                // planted at its path would move the lock somewhere else and
+                // silently let two workers redeem at once.
                 let file = match std::fs::OpenOptions::new()
                     .create(true)
                     .truncate(false)
                     .write(true)
+                    .custom_flags(libc::O_NOFOLLOW)
                     .open(&lock_path)
                 {
                     Ok(f) => f,


### PR DESCRIPTION
`a6c00d9` fixed this for the redemption log. The same pattern was in four more places, all running as root in the master: `persist_mnemonic` (writes the BIP39 phrase controlling every Cashu fund), `set_db_ownership`, `persist_fingerprint`, and the redemption lease.

`O_CREAT` follows an existing symlink unless paired with `O_EXCL`, and path-based `chown`/`set_permissions` follow one too. A link planted before startup therefore redirected the write, the ownership change, or both onto its target. `set_db_ownership` was the worst of them: as a path-based `chown` running as root, it would hand an arbitrary file to the nginx worker user with mode `0660`.

Open with `O_NOFOLLOW` at every site and act on the descriptor — `fchown`, `File::set_permissions` — rather than the path. `set_db_ownership` now opens each of `db`/`-wal`/`-shm` read-only, which is enough for `fchown`/`fchmod` and does not disturb SQLite; a symlink is skipped with a warning instead of silently followed.

`O_NOFOLLOW` guards the final path component only, so the root-owned parent directory remains the trust boundary.