### PR TITLE
fix(sec): key the invoice rate limit on the connection, not client headers

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2150,6 +2150,33 @@ jobs:
           fi
           echo "PASS: Retry-After header present in 429 response"
 
+          # The bucket must key on the connection, never on a client-set header.
+          # Before this was fixed each fresh value minted a fresh bucket, so
+          # these two came back 402 and the limit was bypassable with one flag.
+          echo "Request 4, spoofed X-Real-IP (expect 429 - header ignored)..."
+          r4=$(curl -s -w "\n%{http_code}" --max-time 30 \
+            -H "X-Real-IP: 203.0.113.$((RANDOM % 254 + 1))" \
+            http://0.0.0.0:8000/rate-limited) || true
+          sc4=$(echo "$r4" | tail -n1)
+          if [ "$sc4" -ne 429 ]; then
+            echo "FAIL: spoofed X-Real-IP returned $sc4, expected 429 — limit is keyed on a client header"
+            docker logs nginx-lnd
+            exit 1
+          fi
+          echo "PASS: spoofed X-Real-IP still 429"
+
+          echo "Request 5, spoofed X-Forwarded-For (expect 429)..."
+          r5=$(curl -s -w "\n%{http_code}" --max-time 30 \
+            -H "X-Forwarded-For: 198.51.100.$((RANDOM % 254 + 1)), 10.0.0.1" \
+            http://0.0.0.0:8000/rate-limited) || true
+          sc5=$(echo "$r5" | tail -n1)
+          if [ "$sc5" -ne 429 ]; then
+            echo "FAIL: spoofed X-Forwarded-For returned $sc5, expected 429"
+            docker logs nginx-lnd
+            exit 1
+          fi
+          echo "PASS: spoofed X-Forwarded-For still 429"
+
           # Rate limit counter must be persisted in Redis
           RATE_KEYS=$(docker exec redis redis-cli keys "l402:invoice_rate:*" | wc -l)
           echo "Found $RATE_KEYS rate limit key(s) in Redis"

--- a/docs/config-env-vars.md
+++ b/docs/config-env-vars.md
@@ -305,16 +305,24 @@ real_ip_header    X-Real-IP;       # or X-Forwarded-For
 Listing the trusted ranges is what makes the header safe to believe, and it
 keeps that decision with the operator, who knows the topology.
 
-If a rate-limited request arrives carrying an `X-Real-IP` that does not match
-the connection address, the module logs this once per worker so the
-misconfiguration is visible before users start hitting limits they shouldn't:
+If a rate-limited request arrives carrying an `X-Real-IP` (or an
+`X-Forwarded-For` whose leftmost entry) that does not match the connection
+address, the module logs this once per worker so the misconfiguration is visible
+before users start hitting limits they shouldn't:
 
 ```
 l402_invoice_rate_limit is bucketing by connection address 10.0.0.7, but this
 request carried X-Real-IP: 203.0.113.5. If 10.0.0.7 is your proxy, configure
-`set_real_ip_from 10.0.0.7;` — otherwise every client behind it shares one
-bucket.
+`set_real_ip_from 10.0.0.7;` with `real_ip_header X-Real-IP;` — otherwise every
+client behind it shares one bucket. If nothing proxies to you, a client set that
+header itself and this is safe to ignore; the header is never trusted directly,
+which is why you are seeing this. Logged once per worker.
 ```
+
+On a server with no proxy in front of it anyone can trigger that line by sending
+the header, and it names their address rather than a proxy's — so treat it as a
+prompt to check your topology, not as a `set_real_ip_from` value to paste. If
+you are not behind a proxy, ignore it: the rate limit is already keyed correctly.
 
 ### Realm-scoped access
 

--- a/docs/config-env-vars.md
+++ b/docs/config-env-vars.md
@@ -285,6 +285,37 @@ These are set inside `location {}` blocks in `nginx.conf` (not environment varia
 
 > ¹ **Boolean directives** accept: `on` / `off` / `true` / `false` / `1` / `0` / `yes` / `no` (case-insensitive).
 
+### Rate limiting behind a proxy
+
+`l402_invoice_rate_limit` buckets by the **connection's** source address. It
+deliberately ignores `X-Real-IP` and `X-Forwarded-For`, because a client can set
+those itself — keying on one would let anyone mint a fresh bucket per request
+and bypass the limit entirely.
+
+If nginx sits behind a load balancer or CDN, every request arrives from the
+proxy's address and would share a single bucket. Configure nginx's own realip
+module so the real client address is substituted before the L402 access phase
+runs:
+
+```nginx
+set_real_ip_from  10.0.0.0/8;      # your proxy's range — and only your proxy's
+real_ip_header    X-Real-IP;       # or X-Forwarded-For
+```
+
+Listing the trusted ranges is what makes the header safe to believe, and it
+keeps that decision with the operator, who knows the topology.
+
+If a rate-limited request arrives carrying an `X-Real-IP` that does not match
+the connection address, the module logs this once per worker so the
+misconfiguration is visible before users start hitting limits they shouldn't:
+
+```
+l402_invoice_rate_limit is bucketing by connection address 10.0.0.7, but this
+request carried X-Real-IP: 203.0.113.5. If 10.0.0.7 is your proxy, configure
+`set_real_ip_from 10.0.0.7;` — otherwise every client behind it shares one
+bucket.
+```
+
 ### Realm-scoped access
 
 By default a macaroon is bound to the exact path it was minted for: paying for

--- a/docs/dry-run.md
+++ b/docs/dry-run.md
@@ -103,7 +103,7 @@ Fields:
 | `price_msat` | Effective price in millisatoshis. |
 | `price_source` | `static` (from `nginx.conf`) or `dynamic` (from Redis). |
 | `backend` | LN backend type snapshot: `LND`, `LNURL`, `NWC`, `CLN`, `BOLT12`, `ECLAIR`. |
-| `client_ip` | From `X-Real-IP` → `X-Forwarded-For` → socket address. |
+| `client_ip` | The connection's source address. Proxy headers are not trusted; configure nginx's realip module to substitute the real client address. |
 | `auth_state` | `missing`, `valid`, or `invalid`. |
 | `would_return` | HTTP status enforce mode *would* have used (`200`, `401`, `402`). |
 | `rate_limited` | `true` when `l402_invoice_rate_limit` would have produced a `429` — challenge synthesis was skipped to protect the LN backend. |

--- a/ngx_l402_core/src/lib.rs
+++ b/ngx_l402_core/src/lib.rs
@@ -22,7 +22,7 @@ pub use escaping::{escape_json, html_escape};
 pub use fee::fee_reserve_msat;
 pub use l402_header::parse_l402_header_value;
 pub use p2pk::{parse_p2pk_secret_key, InvalidP2pkKey};
-pub use rate_limit::parse_rate_limit;
+pub use rate_limit::{invoice_rate_limit_key, parse_rate_limit};
 pub use redact::redact_redis_url;
 pub use wallet_seed::{
     derive_wallet_seed, generate_mnemonic, is_valid_mnemonic, wallet_fingerprint, InvalidMnemonic,

--- a/ngx_l402_core/src/rate_limit.rs
+++ b/ngx_l402_core/src/rate_limit.rs
@@ -1,4 +1,26 @@
-//! Parsing of the `l402_invoice_rate_limit` directive value.
+//! The `l402_invoice_rate_limit` directive: parsing its value, and deriving the
+//! Redis key its counter lives under.
+
+/// Build the Redis key for one (client, route) invoice-rate bucket.
+///
+/// Both components are hashed, so the key length is fixed no matter what the
+/// client sends. Hashing only the path — as this once did — left the address
+/// half unbounded, and a multi-kilobyte header became a multi-kilobyte Redis
+/// key, one per distinct value.
+///
+/// The two are separated by a NUL before hashing. Concatenating them directly
+/// would make `("ab", "c")` and `("a", "bc")` collide into one bucket, letting
+/// a crafted path share (and exhaust) another client's limit.
+pub fn invoice_rate_limit_key(client: &str, path: &str) -> String {
+    use cdk::secp256k1::hashes::{sha256, Hash};
+
+    let mut buf = Vec::with_capacity(client.len() + path.len() + 1);
+    buf.extend_from_slice(client.as_bytes());
+    buf.push(0);
+    buf.extend_from_slice(path.as_bytes());
+
+    format!("l402:invoice_rate:{}", sha256::Hash::hash(&buf))
+}
 
 /// Parse a rate-limit directive value into `(max_requests, window_seconds)`.
 /// Accepts `"<N>r/s"`, `"<N>r/m"`, `"<N>r/h"`, or a bare `"<N>"` (defaulting to a
@@ -47,5 +69,41 @@ mod tests {
         assert_eq!(parse_rate_limit("abc"), None);
         assert_eq!(parse_rate_limit("r/s"), None);
         assert_eq!(parse_rate_limit("-5r/m"), None); // u32 rejects negative
+    }
+
+    #[test]
+    fn key_is_stable_for_the_same_inputs() {
+        assert_eq!(
+            invoice_rate_limit_key("1.2.3.4", "/protected"),
+            invoice_rate_limit_key("1.2.3.4", "/protected")
+        );
+    }
+
+    #[test]
+    fn key_separates_clients_and_routes() {
+        let a = invoice_rate_limit_key("1.2.3.4", "/protected");
+        assert_ne!(a, invoice_rate_limit_key("1.2.3.5", "/protected"));
+        assert_ne!(a, invoice_rate_limit_key("1.2.3.4", "/other"));
+    }
+
+    /// Without a separator, ("ab", "c") and ("a", "bc") hash identically and
+    /// share one bucket — a crafted path could then exhaust another client's
+    /// limit.
+    #[test]
+    fn key_is_unambiguous_across_the_boundary() {
+        assert_ne!(
+            invoice_rate_limit_key("ab", "c"),
+            invoice_rate_limit_key("a", "bc")
+        );
+    }
+
+    /// The whole point of hashing: an attacker-supplied component of any length
+    /// yields a fixed-size key, so Redis memory per bucket is bounded.
+    #[test]
+    fn key_length_is_fixed_regardless_of_input_size() {
+        let short = invoice_rate_limit_key("1.2.3.4", "/a");
+        let huge = invoice_rate_limit_key(&"x".repeat(8192), &"y".repeat(8192));
+        assert_eq!(short.len(), huge.len());
+        assert!(short.starts_with("l402:invoice_rate:"));
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3748,11 +3748,16 @@ fn get_client_ip(request: *mut ngx_http_request_t) -> String {
 /// Warn once if this request looks proxied but realip did not rewrite the
 /// connection address.
 ///
-/// The signal: an `X-Real-IP` header that differs from `addr_text`. Either
-/// `set_real_ip_from` is missing, or it does not list this peer — and in both
+/// The signal: a forwarded-client header — `X-Real-IP`, or the leftmost entry
+/// of `X-Forwarded-For` — that differs from `addr_text`. Either
+/// `set_real_ip_from` is missing, or it does not list this peer, and in both
 /// cases every client behind that proxy shares a single rate-limit bucket.
 /// Without this the misconfiguration is invisible until users start hitting
 /// limits they should not.
+///
+/// A client sending the header at a server with no proxy at all produces the
+/// identical signal, and nothing here can tell the two apart, so the message
+/// gives both readings rather than assuming the peer is a proxy.
 ///
 /// # Safety
 /// `request` must be the valid, non-null pointer nginx passes to the access
@@ -3763,18 +3768,37 @@ unsafe fn warn_if_proxy_header_ignored(request: *mut ngx_http_request_t, bucket_
         return;
     }
 
-    // SAFETY: caller guarantees `request` is valid; `x_real_ip` may be null.
-    let header = unsafe {
-        let r = &*request;
-        if r.headers_in.x_real_ip.is_null() {
+    // SAFETY: caller guarantees `request` is valid; either header may be null.
+    let (name, header) = unsafe {
+        let h = &(*request).headers_in;
+        if !h.x_real_ip.is_null() {
+            (
+                "X-Real-IP",
+                (*h.x_real_ip)
+                    .value
+                    .to_str()
+                    .unwrap_or_default()
+                    .trim()
+                    .to_string(),
+            )
+        } else if !h.x_forwarded_for.is_null() {
+            // "client, proxy1, proxy2" — the leftmost entry is the origin, and
+            // the one realip would have substituted.
+            (
+                "X-Forwarded-For",
+                (*h.x_forwarded_for)
+                    .value
+                    .to_str()
+                    .unwrap_or_default()
+                    .split(',')
+                    .next()
+                    .unwrap_or_default()
+                    .trim()
+                    .to_string(),
+            )
+        } else {
             return;
         }
-        (*r.headers_in.x_real_ip)
-            .value
-            .to_str()
-            .unwrap_or_default()
-            .trim()
-            .to_string()
     };
 
     // Equal means realip already substituted it — correctly configured.
@@ -3785,10 +3809,13 @@ unsafe fn warn_if_proxy_header_ignored(request: *mut ngx_http_request_t, bucket_
     if !REPORTED.swap(true, std::sync::atomic::Ordering::Relaxed) {
         warn!(
             "⚠️ l402_invoice_rate_limit is bucketing by connection address {addr}, but this \
-             request carried X-Real-IP: {hdr}. If {addr} is your proxy, configure \
-             `set_real_ip_from {addr};` — otherwise every client behind it shares one bucket. \
-             The header is not trusted directly because a client can set it.",
+             request carried {name}: {hdr}. If {addr} is your proxy, configure \
+             `set_real_ip_from {addr};` with `real_ip_header {name};` — otherwise every client \
+             behind it shares one bucket. If nothing proxies to you, a client set that header \
+             itself and this is safe to ignore; the header is never trusted directly, which is \
+             why you are seeing this. Logged once per worker.",
             addr = bucket_addr,
+            name = name,
             hdr = ngx_l402_core::escape_json(&header),
         );
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2009,6 +2009,8 @@ pub unsafe extern "C" fn l402_access_handler_wrapper(request: *mut ngx_http_requ
     if result == 402 {
         if let Some((max_requests, window_secs)) = invoice_rate_limit {
             let client_ip = get_client_ip(request);
+            // SAFETY: `request` is the valid pointer nginx passed to this handler.
+            unsafe { warn_if_proxy_header_ignored(request, &client_ip) };
             if !check_invoice_rate_limit(&client_ip, &request_path, max_requests, window_secs) {
                 metrics::inc(metrics::Metric::RateLimitedTotal);
                 ngx_log_error!(
@@ -2967,6 +2969,8 @@ fn handle_dry_run_passthrough(
     let rate_limited = if would_return == 402 {
         match invoice_rate_limit {
             Some((max_requests, window_secs)) => {
+                // SAFETY: `request` is the valid pointer nginx passed to this handler.
+                unsafe { warn_if_proxy_header_ignored(request, &client_ip) };
                 !check_invoice_rate_limit(&client_ip, request_path, max_requests, window_secs)
             }
             None => false,
@@ -3701,11 +3705,26 @@ pub unsafe extern "C" fn ngx_http_l402_realm_set(
     std::ptr::null_mut()
 }
 
-/// Returns the client IP, preferring X-Real-IP then the first entry of
-/// X-Forwarded-For over the direct socket address. Falls back to `"unknown"`.
+/// Returns the client address from the connection, falling back to
+/// `"unknown"`.
 ///
-/// Note: X-Forwarded-For can be spoofed by clients unless nginx is configured
-/// to strip or overwrite it via the realip module before reaching this handler.
+/// This is deliberately the *socket* address and never `X-Real-IP` or
+/// `X-Forwarded-For`. Those are set by the client unless a trusted proxy
+/// overwrites them, so keying the invoice rate limiter on one let anyone mint a
+/// fresh bucket per request (`curl -H "X-Real-IP: $RANDOM"`) and bypass the
+/// limit entirely.
+///
+/// Deployments behind a proxy get the real client address by configuring
+/// nginx's own realip module, which rewrites `connection->addr_text` before the
+/// access phase runs:
+///
+/// ```nginx
+/// set_real_ip_from  10.0.0.0/8;   # your proxy, and only your proxy
+/// real_ip_header    X-Real-IP;
+/// ```
+///
+/// That keeps the trust decision in nginx, where the operator states which
+/// proxies are trusted, rather than in a module that would have to guess.
 fn get_client_ip(request: *mut ngx_http_request_t) -> String {
     // SAFETY: called only from `l402_access_handler_wrapper`, where `request`
     // is the pointer nginx passed to the access handler and is guaranteed
@@ -3714,41 +3733,64 @@ fn get_client_ip(request: *mut ngx_http_request_t) -> String {
         if request.is_null() {
             return "unknown".to_string();
         }
-        let r = &*request;
-
-        // X-Real-IP: single IP set by a trusted reverse proxy
-        if !r.headers_in.x_real_ip.is_null() {
-            let val = (*r.headers_in.x_real_ip)
-                .value
-                .to_str()
-                .unwrap_or_default()
-                .trim()
-                .to_string();
-            if !val.is_empty() {
-                return val;
-            }
-        }
-
-        // X-Forwarded-For: "client, proxy1, proxy2" — leftmost is the origin
-        if !r.headers_in.x_forwarded_for.is_null() {
-            let val_str = (*r.headers_in.x_forwarded_for)
-                .value
-                .to_str()
-                .unwrap_or_default();
-            if let Some(ip) = val_str.split(',').next() {
-                let ip = ip.trim();
-                if !ip.is_empty() {
-                    return ip.to_string();
-                }
-            }
-        }
-
-        // Direct socket address — unreliable behind a load balancer
-        let conn = r.connection;
+        let conn = (*request).connection;
         if conn.is_null() {
             return "unknown".to_string();
         }
-        (*conn).addr_text.to_str().unwrap_or_default().to_string()
+        let addr = (*conn).addr_text.to_str().unwrap_or_default();
+        if addr.is_empty() {
+            return "unknown".to_string();
+        }
+        addr.to_string()
+    }
+}
+
+/// Warn once if this request looks proxied but realip did not rewrite the
+/// connection address.
+///
+/// The signal: an `X-Real-IP` header that differs from `addr_text`. Either
+/// `set_real_ip_from` is missing, or it does not list this peer — and in both
+/// cases every client behind that proxy shares a single rate-limit bucket.
+/// Without this the misconfiguration is invisible until users start hitting
+/// limits they should not.
+///
+/// # Safety
+/// `request` must be the valid, non-null pointer nginx passes to the access
+/// handler.
+unsafe fn warn_if_proxy_header_ignored(request: *mut ngx_http_request_t, bucket_addr: &str) {
+    static REPORTED: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
+    if REPORTED.load(std::sync::atomic::Ordering::Relaxed) || request.is_null() {
+        return;
+    }
+
+    // SAFETY: caller guarantees `request` is valid; `x_real_ip` may be null.
+    let header = unsafe {
+        let r = &*request;
+        if r.headers_in.x_real_ip.is_null() {
+            return;
+        }
+        (*r.headers_in.x_real_ip)
+            .value
+            .to_str()
+            .unwrap_or_default()
+            .trim()
+            .to_string()
+    };
+
+    // Equal means realip already substituted it — correctly configured.
+    if header.is_empty() || header == bucket_addr {
+        return;
+    }
+
+    if !REPORTED.swap(true, std::sync::atomic::Ordering::Relaxed) {
+        warn!(
+            "⚠️ l402_invoice_rate_limit is bucketing by connection address {addr}, but this \
+             request carried X-Real-IP: {hdr}. If {addr} is your proxy, configure \
+             `set_real_ip_from {addr};` — otherwise every client behind it shares one bucket. \
+             The header is not trusted directly because a client can set it.",
+            addr = bucket_addr,
+            hdr = ngx_l402_core::escape_json(&header),
+        );
     }
 }
 
@@ -3764,13 +3806,7 @@ fn check_invoice_rate_limit(ip: &str, path: &str, max_requests: u32, window_secs
         return true;
     };
 
-    // Hash the request path so the Redis key has a bounded length and an
-    // attacker cannot exhaust Redis memory or cause key collisions by sending
-    // arbitrarily long / crafted paths. Mirrors preimage_redis_key().
-    let mut hasher = Sha256::new();
-    hasher.update(path.as_bytes());
-    let path_hash = hex::encode(hasher.finalize());
-    let key = format!("l402:invoice_rate:{}:{}", ip, &path_hash[..16]);
+    let key = ngx_l402_core::invoice_rate_limit_key(ip, path);
 
     let count: u64 = match redis::Script::new(
         r#"


### PR DESCRIPTION
`get_client_ip` preferred `X-Real-IP`, then `X-Forwarded-For`, over the socket address, and that value keyed the Redis bucket. Both headers are client-set unless a trusted proxy overwrites them, and the shipped `nginx.conf` configures no realip module, so `curl -H "X-Real-IP: $RANDOM"` produced a fresh bucket per request and the limit never applied.

Read the connection's source address only. Proxied deployments substitute the real client address with nginx's realip module, which rewrites `addr_text` before the access phase — that keeps the trust decision with the operator, who states which proxies are trusted, instead of in a module that would have to guess.

The key derivation also hashed only the path, leaving the address half unbounded: a multi-kilobyte header became a multi-kilobyte Redis key, one per distinct value. Hash both components, separated by a NUL — concatenating them directly makes `("ab", "c")` and `("a", "bc")` collide into a single bucket, so a crafted path could exhaust another client's limit.

**Behaviour change:** a deployment behind a proxy without realip configured moves from per-client buckets to one shared bucket. To keep that from being silent, warn once per worker when a rate-limited request carries an `X-Real-IP` that differs from the connection address, naming the `set_real_ip_from` line to add:

```nginx
set_real_ip_from  10.0.0.7;    # your proxy — and only your proxy
real_ip_header    X-Real-IP;
```