### PR TITLE
fix(sec): close the metrics endpoint by default

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -233,12 +233,19 @@ jobs:
 
           # Metrics endpoint — must serve text/plain Prometheus exposition.
           # Poll multiple times to handle per-worker counter copies.
+          #
+          # /metrics is ACL'd to localhost in nginx.conf, so scrape from inside
+          # the container's network namespace. The runtime image has no curl of
+          # its own (the Dockerfile installs it only in the builder stage), so
+          # borrow one that shares the network.
           echo "Scraping /metrics endpoint..."
           metrics_code=0
           metrics_resp=""
           dry_run_total=""
           for i in {1..10}; do
-            metrics_resp=$(curl -s -i -w "\n%{http_code}" --max-time 30 -H "Connection: close" http://0.0.0.0:8000/metrics) || true
+            metrics_resp=$(docker run --rm --network container:nginx-lnurl curlimages/curl:8.11.1 \
+              -s -i -w "\n%{http_code}" --max-time 30 -H "Connection: close" \
+              http://127.0.0.1:8000/metrics) || true
             metrics_code=$(echo "$metrics_resp" | tail -n1); metrics_code=${metrics_code:-000}
             if [ "$metrics_code" -eq 200 ]; then
               dry_run_total=$(echo "$metrics_resp" | awk '/^l402_dry_run_requests_total / {print $2}')
@@ -256,6 +263,18 @@ jobs:
             exit 1
           fi
           echo "PASS: /metrics returned 200"
+
+          # …and the ACL must actually deny a scrape from off-host. This is the
+          # regression guard: the endpoint publishes revenue and traffic
+          # counters, and this config ships in the Docker image.
+          ext_code=$(curl -s -o /dev/null -w "%{http_code}" --max-time 15 \
+            -H "Connection: close" http://0.0.0.0:8000/metrics || echo 000)
+          if [ "$ext_code" != "403" ]; then
+            echo "FAIL: /metrics reachable from outside the container (got $ext_code, expected 403)"
+            docker logs nginx-lnurl
+            exit 1
+          fi
+          echo "PASS: /metrics denied from outside (403)"
 
           if ! echo "$metrics_resp" | grep -qi "^Content-Type: text/plain"; then
             echo "FAIL: /metrics Content-Type is not text/plain"

--- a/docs/dry-run.md
+++ b/docs/dry-run.md
@@ -123,15 +123,22 @@ sudo tail -f /var/log/nginx/error.log \
 The `l402_metrics` directive turns a location into a Prometheus scrape
 endpoint. It serves counters in text exposition format v0.0.4.
 
+The shipped `nginx.conf` closes it to everything but localhost, because the
+counters carry invoice volume and revenue signals and that file ships inside the
+Docker image. Widen `allow` to reach it from your scrape host:
+
 ```nginx
 location = /metrics {
-    l402_metrics;
-
-    # Production: restrict to your scrape network.
-    allow 10.0.0.0/8;
+    allow 127.0.0.1;
+    allow ::1;
+    allow 10.0.0.0/8;      # your Prometheus host or monitoring subnet
     deny  all;
+    l402_metrics;
 }
 ```
+
+Scraping from another container puts the request on the Docker bridge, not
+loopback — allow that network rather than removing `deny all`.
 
 Scrape it with a standard Prometheus config:
 

--- a/nginx.conf
+++ b/nginx.conf
@@ -172,19 +172,19 @@ http {
         # Prometheus scrape endpoint. Emits `l402_*` and `l402_dry_run_*`
         # counters in text exposition format (v0.0.4).
         #
-        # ⚠️ SECURITY: this endpoint is UNAUTHENTICATED and exposes operational
-        # data (invoice counts, payment/error rates, client IPs). In production
-        # you MUST restrict it. Uncomment and adapt the allow/deny block below
-        # to your Prometheus host / monitoring subnet, or block it at the
-        # firewall / reverse proxy. Example:
+        # Prometheus metrics. Closed by default: the counters expose invoice
+        # volume, payment/error rates and revenue signals, and this file ships
+        # in the Docker image — an open default would publish that for every
+        # deployment that never edited it.
         #
-        #     location = /metrics {
-        #         allow 10.0.0.0/8;      # your monitoring subnet
-        #         allow 127.0.0.1;
-        #         deny  all;
-        #         l402_metrics;
-        #     }
+        # Widen `allow` to your Prometheus host or monitoring subnet, e.g.
+        #     allow 10.0.0.0/8;
+        # Scraping from another container? Allow that network rather than
+        # removing `deny all`.
         location = /metrics {
+            allow 127.0.0.1;
+            allow ::1;
+            deny  all;
             l402_metrics;
         }
 


### PR DESCRIPTION
`nginx.conf` shipped the access-control block commented out and the open location live, and the Dockerfile copies this file into the image — so every deployment that never edited it published `l402_payments_valid_total`, `l402_payments_lightning_total` and `l402_dry_run_price_msat_sum` to anyone who asked. That is revenue, transaction volume and payment-method mix.

Make the `allow`/`deny` block the live one, restricted to loopback, and document widening it to a scrape host. CI scraped through the published port, which now arrives via the Docker bridge and is denied, so it scrapes from inside the container's network namespace instead — the runtime image has no curl of its own, so a curl container shares the namespace. CI also asserts an external scrape returns `403`, so removing the block fails the build rather than silently reopening the endpoint.