### PR TITLE
feat(l402): add l402_exempt_methods to skip the paywall by HTTP method

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -182,6 +182,48 @@ jobs:
 
           echo "✅ Multi-tenant LNURL Lightning integration tests completed!"
 
+      - name: Run Integration Tests - Exempt Methods
+        run: |
+          source .github/scripts/ci-wait.sh
+          echo "Testing l402_exempt_methods on /exempt-head (HEAD exempt, GET paid)..."
+
+          # HEAD is exempt: the access handler declines before minting a
+          # challenge, so the request reaches the file handler and returns 200,
+          # never 402. No LN backend is touched (no invoice), so polling is safe.
+          echo "HEAD /exempt-head (expect 200, must not be 402)..."
+          head_code=$(curl -s -o /dev/null -w "%{http_code}" --max-time 30 -I http://0.0.0.0:8000/exempt-head) || head_code="000"
+          if [ "$head_code" -eq 402 ]; then
+            echo "FAIL: HEAD /exempt-head returned 402 — an exempt method was paywalled"
+            docker logs nginx-lnurl
+            exit 1
+          fi
+          if [ "$head_code" -ne 200 ]; then
+            echo "FAIL: HEAD /exempt-head returned $head_code, expected 200 (exempt → served)"
+            docker logs nginx-lnurl
+            exit 1
+          fi
+          echo "PASS: HEAD /exempt-head returned 200 (exempt, not paywalled)"
+
+          # GET on the SAME location is not exempt: it still returns 402 with an
+          # L402 challenge. curl_until (3 tries) avoids hammering the external
+          # LNURL provider that mints the invoice.
+          echo "GET /exempt-head (expect 402 with L402 challenge)..."
+          curl_until 402 -L http://0.0.0.0:8000/exempt-head
+          if [ "$status_code" -ne 402 ]; then
+            echo "FAIL: GET /exempt-head returned $status_code, expected 402 (non-exempt method must be paid)"
+            docker logs nginx-lnurl
+            exit 1
+          fi
+          if ! echo "$response" | grep -q 'WWW-Authenticate: L402 macaroon='; then
+            echo "FAIL: GET /exempt-head 402 is missing the WWW-Authenticate: L402 challenge"
+            echo "$response"
+            docker logs nginx-lnurl
+            exit 1
+          fi
+          echo "PASS: GET /exempt-head returned 402 with an L402 challenge"
+
+          echo "✅ l402_exempt_methods integration tests completed!"
+
       - name: Run Integration Tests - Dry-Run (Shadow) Mode & Metrics
         run: |
           echo "Testing l402_dry_run shadow mode and l402_metrics endpoint..."

--- a/examples/paywalled-blossom/README.md
+++ b/examples/paywalled-blossom/README.md
@@ -144,9 +144,13 @@ CASHU_REDEEM_ON_LIGHTNING=false
   crosses the wire **twice** unless it pre-pays via a `HEAD /upload` (BUD-06)
   preflight. Cashu is the clean path: `X-Cashu` rides its own header, so it
   coexists with a BUD-02 upload auth; L402 rides `Authorization` and only works
-  when the upload carries no auth (this example's `requireAuth: false`). Storage is a flat
-  90 days regardless of amount — pricing *by* payment would need ngx_l402 to pass
-  a TTL to the storage layer, which it can't today.
+  when the upload carries no auth (this example's `requireAuth: false`). A
+  `HEAD /<sha>` presence check is free for any client (`l402_exempt_methods HEAD`
+  on the download location), so a publisher that only references already-stored
+  blobs never PUTs: pay-upload them with payblob, then publish. Storage is a flat
+  90 days regardless of amount — pricing
+  *by* payment would need ngx_l402 to pass a TTL to the storage layer, which it
+  can't today.
 - **Pricing is flat per blob** — a 1 KB blob and a 1 GB blob both cost 10 sats,
   and uploads are uncapped (`client_max_body_size 0`). Simple, and fine when your
   blobs are roughly one size or you trust who's paying. Set `client_max_body_size`

--- a/examples/paywalled-blossom/nginx.conf.template
+++ b/examples/paywalled-blossom/nginx.conf.template
@@ -55,6 +55,11 @@ http {
             l402_realm               "blossom-read";
             l402_macaroon_timeout    600;            # one payment → 10 min of pulls
             l402_indefinite_access   on;             # let that token be reused
+            # Has-blob checks (HEAD /<sha>) are informational (BUD-01/BUD-07), so
+            # leave them free; only GET content is paid. This also lets clients
+            # publish here: pre-upload the blobs (paid PUT), then a publisher whose
+            # presence check is a free HEAD skips re-uploading.
+            l402_exempt_methods      HEAD;
 
             # A realm token buys a WINDOW of egress, not one blob — so bound the
             # throughput rather than the clock. Shortening the window instead is a

--- a/nginx.conf
+++ b/nginx.conf
@@ -84,6 +84,21 @@ http {
             try_files $uri $uri/index.html =404;
         }
 
+        # Exempt-method endpoint: HEAD skips the paywall, GET is charged.
+        # Exercises l402_exempt_methods — an informational HEAD presence check
+        # must pass through unpaywalled while GET still returns 402. HEAD
+        # resolves to the existing index.html (declined before the challenge, so
+        # no invoice is minted → 200); GET is blocked in the access phase → 402.
+        location /exempt-head {
+            root   /usr/share/nginx/html;
+            l402    on;
+            l402_amount_msat_default    10000;
+            l402_macaroon_timeout 0;
+            l402_exempt_methods HEAD;
+
+            try_files $uri /index.html =404;
+        }
+
         # Structured JSON logging endpoint: same as /protected but with
         # l402_log_format json, so CI can assert the l402_* JSON events land
         # in the container logs. A 1r/m invoice rate limit lets the same CI

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,8 @@ use ngx::ffi::{
     ngx_http_discard_request_body, ngx_http_finalize_request, ngx_http_handler_pt,
     ngx_http_module_t, ngx_http_phases_NGX_HTTP_ACCESS_PHASE, ngx_http_request_t, ngx_int_t,
     ngx_log_s, ngx_module_t, ngx_shared_memory_add, ngx_shm_zone_t, ngx_slab_alloc,
-    ngx_slab_pool_t, ngx_str_t, ngx_test_config, ngx_uint_t, NGX_CONF_NOARGS, NGX_CONF_TAKE1,
+    ngx_slab_pool_t, ngx_str_t, ngx_test_config, ngx_uint_t, NGX_CONF_1MORE, NGX_CONF_NOARGS,
+    NGX_CONF_TAKE1,
     NGX_DECLINED, NGX_DONE, NGX_ERROR, NGX_HTTP_COPY, NGX_HTTP_DELETE, NGX_HTTP_GET, NGX_HTTP_HEAD,
     NGX_HTTP_INTERNAL_SERVER_ERROR, NGX_HTTP_LOCK, NGX_HTTP_LOC_CONF, NGX_HTTP_LOC_CONF_OFFSET,
     NGX_HTTP_MAIN_CONF, NGX_HTTP_MKCOL, NGX_HTTP_MODULE, NGX_HTTP_MOVE, NGX_HTTP_NOT_ALLOWED,
@@ -1336,6 +1337,11 @@ unsafe impl HttpModuleServerConf for L402Module {
 #[derive(Debug, Default)]
 pub struct ModuleConfig {
     enable: bool,
+    // HTTP methods (uppercase) exempt from the paywall for this location, set via
+    // `l402_exempt_methods HEAD;`. Exempt requests pass through unpaywalled — e.g.
+    // a Blossom has-blob `HEAD /<sha>` should not require payment (BUD-07: HEAD
+    // endpoints are informational). Empty = every method is paywalled as before.
+    exempt_methods: Vec<String>,
     amount_msat: i64,
     macaroon_timeout: i64,
     // Opt-in location-scoped ("realm") caveat. When set via `l402_realm "name"`,
@@ -1369,7 +1375,7 @@ pub struct ModuleConfig {
     manifest_hidden: bool,
 }
 
-pub static mut NGX_HTTP_L402_COMMANDS: [ngx_command_t; 14] = [
+pub static mut NGX_HTTP_L402_COMMANDS: [ngx_command_t; 15] = [
     ngx_command_t {
         name: ngx_string!("l402"),
         type_: (NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1) as ngx_uint_t,
@@ -1475,6 +1481,14 @@ pub static mut NGX_HTTP_L402_COMMANDS: [ngx_command_t; 14] = [
         offset: 0,
         post: std::ptr::null_mut(),
     },
+    ngx_command_t {
+        name: ngx_string!("l402_exempt_methods"),
+        type_: (NGX_HTTP_LOC_CONF | NGX_CONF_1MORE) as ngx_uint_t,
+        set: Some(ngx_http_l402_exempt_methods_set),
+        conf: NGX_HTTP_LOC_CONF_OFFSET,
+        offset: 0,
+        post: std::ptr::null_mut(),
+    },
     ngx_command_t::empty(),
 ];
 
@@ -1558,6 +1572,9 @@ impl Merge for ModuleConfig {
         }
         if self.log_format_json.is_none() {
             self.log_format_json = prev.log_format_json;
+        }
+        if self.exempt_methods.is_empty() && !prev.exempt_methods.is_empty() {
+            self.exempt_methods = prev.exempt_methods.clone();
         }
         if prev.manifest_hidden {
             self.manifest_hidden = true;
@@ -1798,6 +1815,16 @@ pub unsafe extern "C" fn l402_access_handler_wrapper(request: *mut ngx_http_requ
         if !conf.enable {
             ngx_log_error!(NGX_LOG_INFO, log_ref, "L402 is disabled for this location");
             return NGX_DECLINED as isize;
+        }
+
+        // Methods the operator marked exempt (e.g. a Blossom has-blob `HEAD`) skip
+        // the paywall entirely and pass through like a free location.
+        if !conf.exempt_methods.is_empty() {
+            let m = method_caveat_value(method);
+            if conf.exempt_methods.iter().any(|em| em.as_str() == m) {
+                ngx_log_error!(NGX_LOG_INFO, log_ref, "L402 exempt method; passing through");
+                return NGX_DECLINED as isize;
+            }
         }
 
         let amount_msat = conf.amount_msat;
@@ -3726,6 +3753,37 @@ pub unsafe extern "C" fn ngx_http_l402_realm_set(
             "⚙️ l402_realm = \"{}\" — one payment authorizes this whole location",
             val
         );
+    }
+
+    std::ptr::null_mut()
+}
+
+/// `l402_exempt_methods HEAD [GET ...];` — HTTP methods that skip the paywall for
+/// this location. Stored uppercase; the access handler lets matching requests
+/// through unpaywalled (e.g. a Blossom has-blob `HEAD /<sha>`).
+pub unsafe extern "C" fn ngx_http_l402_exempt_methods_set(
+    cf: *mut ngx_conf_t,
+    _cmd: *mut ngx_command_t,
+    conf: *mut c_void,
+) -> *mut c_char {
+    // SAFETY: `cf`, `conf`, and `(*cf).args` are valid during config parsing;
+    // NGX_CONF_1MORE guarantees at least one argument after the directive name.
+    unsafe {
+        let conf = &mut *(conf as *mut ModuleConfig);
+        let args_arr = &*(*cf).args;
+        let args = args_arr.elts as *mut ngx_str_t;
+        let mut methods = Vec::new();
+        for i in 1..(args_arr.nelts as usize) {
+            let v = (*args.add(i)).to_str().unwrap_or_default().trim().to_uppercase();
+            if !v.is_empty() {
+                methods.push(v);
+            }
+        }
+        info!(
+            "⚙️ l402_exempt_methods = {:?} — these methods skip the paywall here",
+            methods
+        );
+        conf.exempt_methods = methods;
     }
 
     std::ptr::null_mut()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,13 +10,13 @@ use ngx::ffi::{
     ngx_http_module_t, ngx_http_phases_NGX_HTTP_ACCESS_PHASE, ngx_http_request_t, ngx_int_t,
     ngx_log_s, ngx_module_t, ngx_shared_memory_add, ngx_shm_zone_t, ngx_slab_alloc,
     ngx_slab_pool_t, ngx_str_t, ngx_test_config, ngx_uint_t, NGX_CONF_1MORE, NGX_CONF_NOARGS,
-    NGX_CONF_TAKE1,
-    NGX_DECLINED, NGX_DONE, NGX_ERROR, NGX_HTTP_COPY, NGX_HTTP_DELETE, NGX_HTTP_GET, NGX_HTTP_HEAD,
-    NGX_HTTP_INTERNAL_SERVER_ERROR, NGX_HTTP_LOCK, NGX_HTTP_LOC_CONF, NGX_HTTP_LOC_CONF_OFFSET,
-    NGX_HTTP_MAIN_CONF, NGX_HTTP_MKCOL, NGX_HTTP_MODULE, NGX_HTTP_MOVE, NGX_HTTP_NOT_ALLOWED,
-    NGX_HTTP_OPTIONS, NGX_HTTP_PATCH, NGX_HTTP_POST, NGX_HTTP_PROPFIND, NGX_HTTP_PROPPATCH,
-    NGX_HTTP_PUT, NGX_HTTP_SRV_CONF, NGX_HTTP_TRACE, NGX_HTTP_UNLOCK, NGX_LOG_EMERG, NGX_LOG_ERR,
-    NGX_LOG_INFO, NGX_LOG_NOTICE, NGX_LOG_WARN, NGX_OK, NGX_RS_MODULE_SIGNATURE,
+    NGX_CONF_TAKE1, NGX_DECLINED, NGX_DONE, NGX_ERROR, NGX_HTTP_COPY, NGX_HTTP_DELETE,
+    NGX_HTTP_GET, NGX_HTTP_HEAD, NGX_HTTP_INTERNAL_SERVER_ERROR, NGX_HTTP_LOCK, NGX_HTTP_LOC_CONF,
+    NGX_HTTP_LOC_CONF_OFFSET, NGX_HTTP_MAIN_CONF, NGX_HTTP_MKCOL, NGX_HTTP_MODULE, NGX_HTTP_MOVE,
+    NGX_HTTP_NOT_ALLOWED, NGX_HTTP_OPTIONS, NGX_HTTP_PATCH, NGX_HTTP_POST, NGX_HTTP_PROPFIND,
+    NGX_HTTP_PROPPATCH, NGX_HTTP_PUT, NGX_HTTP_SRV_CONF, NGX_HTTP_TRACE, NGX_HTTP_UNLOCK,
+    NGX_LOG_EMERG, NGX_LOG_ERR, NGX_LOG_INFO, NGX_LOG_NOTICE, NGX_LOG_WARN, NGX_OK,
+    NGX_RS_MODULE_SIGNATURE,
 };
 use ngx::http::{
     HTTPStatus, HttpModule, HttpModuleLocationConf, HttpModuleMainConf, HttpModuleServerConf,
@@ -1339,8 +1339,8 @@ pub struct ModuleConfig {
     enable: bool,
     // HTTP methods (uppercase) exempt from the paywall for this location, set via
     // `l402_exempt_methods HEAD;`. Exempt requests pass through unpaywalled — e.g.
-    // a Blossom has-blob `HEAD /<sha>` should not require payment (BUD-07: HEAD
-    // endpoints are informational). Empty = every method is paywalled as before.
+    // an informational `HEAD` presence check that should not require payment.
+    // Empty = every method is paywalled as before.
     exempt_methods: Vec<String>,
     amount_msat: i64,
     macaroon_timeout: i64,
@@ -1817,7 +1817,7 @@ pub unsafe extern "C" fn l402_access_handler_wrapper(request: *mut ngx_http_requ
             return NGX_DECLINED as isize;
         }
 
-        // Methods the operator marked exempt (e.g. a Blossom has-blob `HEAD`) skip
+        // Methods the operator marked exempt (e.g. an informational `HEAD`) skip
         // the paywall entirely and pass through like a free location.
         if !conf.exempt_methods.is_empty() {
             let m = method_caveat_value(method);
@@ -2760,9 +2760,12 @@ pub unsafe extern "C" fn init_module(cycle: *mut ngx_cycle_s) -> isize {
             let has_lnurl_dest = std::env::var("LNURL_ADDRESS")
                 .map(|a| !a.trim().is_empty())
                 .unwrap_or(false)
-                || collect_route_snapshots()
-                    .iter()
-                    .any(|s| s.lnurl_addr.as_deref().map(|a| !a.trim().is_empty()).unwrap_or(false));
+                || collect_route_snapshots().iter().any(|s| {
+                    s.lnurl_addr
+                        .as_deref()
+                        .map(|a| !a.trim().is_empty())
+                        .unwrap_or(false)
+                });
             if !has_lnurl_dest {
                 ngx_log_error!(
                     NGX_LOG_WARN,
@@ -3760,21 +3763,29 @@ pub unsafe extern "C" fn ngx_http_l402_realm_set(
 
 /// `l402_exempt_methods HEAD [GET ...];` — HTTP methods that skip the paywall for
 /// this location. Stored uppercase; the access handler lets matching requests
-/// through unpaywalled (e.g. a Blossom has-blob `HEAD /<sha>`).
+/// through unpaywalled (e.g. an informational `HEAD` presence check).
+///
+/// # Safety
+/// `cf` and `conf` are the valid, non-null pointers Nginx passes to
+/// directive-parsing callbacks; `conf` points to this location's `ModuleConfig`.
+/// `(*cf).args` holds at least one argument after the name because the directive
+/// is declared `NGX_CONF_1MORE`.
 pub unsafe extern "C" fn ngx_http_l402_exempt_methods_set(
     cf: *mut ngx_conf_t,
     _cmd: *mut ngx_command_t,
     conf: *mut c_void,
 ) -> *mut c_char {
-    // SAFETY: `cf`, `conf`, and `(*cf).args` are valid during config parsing;
-    // NGX_CONF_1MORE guarantees at least one argument after the directive name.
     unsafe {
         let conf = &mut *(conf as *mut ModuleConfig);
         let args_arr = &*(*cf).args;
         let args = args_arr.elts as *mut ngx_str_t;
         let mut methods = Vec::new();
-        for i in 1..(args_arr.nelts as usize) {
-            let v = (*args.add(i)).to_str().unwrap_or_default().trim().to_uppercase();
+        for i in 1..args_arr.nelts {
+            let v = (*args.add(i))
+                .to_str()
+                .unwrap_or_default()
+                .trim()
+                .to_uppercase();
             if !v.is_empty() {
                 methods.push(v);
             }


### PR DESCRIPTION
A location could not paywall some methods while leaving others free, so an informational HEAD (a presence check that must not require payment) returned 402 alongside a paid GET. That also blocked publishing to a paid server: the HEAD check failed, so a client re-uploaded and hit the paid PUT.

Add a per-location l402_exempt_methods HEAD [GET ...]; directive. Listed methods pass through unpaywalled (the access handler declines before minting a challenge) and inherit into nested locations; unlisted methods stay paid.

Wire l402_exempt_methods HEAD; into the paywalled-blossom example so a HEAD presence check is free for any client: pre-upload the paid blobs, then publish without re-uploading.